### PR TITLE
feat: externalize prompts (issue #198 Phase 1)

### DIFF
--- a/cmd/v100/cmd_wake.go
+++ b/cmd/v100/cmd_wake.go
@@ -1642,7 +1642,16 @@ func buildStepPrompt(task *config.WakeTask, stepIndex int, step config.WakeTaskS
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "Task: %s — Step %d of %d: %s\n", task.Name, stepIndex+1, len(task.Steps), step.Name)
-	fmt.Fprintf(&b, "%s\n\n", step.Prompt)
+	// Resolve external prompt_path if set, falling back to inline Prompt.
+	// On read failure, fall back silently to inline so a missing file does not
+	// break wake execution — the runtime warning is left to the caller.
+	stepText := step.Prompt
+	if resolved, err := step.ResolvePrompt(config.XDGConfigDir()); err == nil && resolved != "" {
+		stepText = resolved
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %v (falling back to inline prompt)\n", err)
+	}
+	fmt.Fprintf(&b, "%s\n\n", stepText)
 
 	if enabled := step.EnabledTools(); len(enabled) > 0 {
 		fmt.Fprintf(&b, "Available tools: %s. Use them as needed.\n", strings.Join(enabled, ", "))

--- a/cmd/v100/helpers.go
+++ b/cmd/v100/helpers.go
@@ -760,7 +760,14 @@ func registerAgentTool(cfg *config.Config, reg *tools.Registry, trace *core.Trac
 			Dir: workspace,
 		}
 
-		systemPrompt := strings.TrimSpace(roleCfg.SystemPrompt)
+		// Resolve sub-agent system prompt, preferring system_prompt_path when set.
+		// Falls back to inline SystemPrompt on read error, then to a default.
+		systemPrompt, err := roleCfg.ResolvePrompt(config.XDGConfigDir())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %v (falling back to inline system_prompt)\n", err)
+			systemPrompt = roleCfg.SystemPrompt
+		}
+		systemPrompt = strings.TrimSpace(systemPrompt)
 		if systemPrompt == "" {
 			systemPrompt = "You are a focused sub-agent. Complete the given task concisely. Use the tools available to you."
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,10 +82,11 @@ type WakeTask struct {
 
 // WakeTaskStep is a single step within a wake task.
 type WakeTaskStep struct {
-	Name   string   `toml:"name"`
-	Tool   string   `toml:"tool,omitempty"`
-	Tools  []string `toml:"tools,omitempty"` // multi-tool allowlist; merged with Tool if both set
-	Prompt string   `toml:"prompt"`
+	Name       string   `toml:"name"`
+	Tool       string   `toml:"tool,omitempty"`
+	Tools      []string `toml:"tools,omitempty"` // multi-tool allowlist; merged with Tool if both set
+	Prompt     string   `toml:"prompt"`
+	PromptPath string   `toml:"prompt_path,omitempty"` // optional path to external prompt file (.md/.txt)
 }
 
 // EnabledTools returns the deduplicated list of tools for this step.
@@ -134,12 +135,13 @@ type PolicyConfig struct {
 
 // AgentConfig holds sub-agent persona definitions.
 type AgentConfig struct {
-	SystemPrompt  string   `toml:"system_prompt"`
-	Tools         []string `toml:"tools"`
-	Model         string   `toml:"model"`
-	BudgetSteps   int      `toml:"budget_steps"`
-	BudgetTokens  int      `toml:"budget_tokens"`
-	BudgetCostUSD float64  `toml:"budget_cost_usd"`
+	SystemPrompt     string   `toml:"system_prompt"`
+	SystemPromptPath string   `toml:"system_prompt_path"` // optional path to .md/.txt file containing the system prompt
+	Tools            []string `toml:"tools"`
+	Model            string   `toml:"model"`
+	BudgetSteps      int      `toml:"budget_steps"`
+	BudgetTokens     int      `toml:"budget_tokens"`
+	BudgetCostUSD    float64  `toml:"budget_cost_usd"`
 }
 
 // DefaultsConfig holds run-level defaults.

--- a/internal/config/prompt_resolver.go
+++ b/internal/config/prompt_resolver.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ResolvePrompt returns the resolved system prompt for an agent.
+// If SystemPromptPath is set, it reads the file (resolved relative to baseDir if not absolute).
+// Otherwise, falls back to inline SystemPrompt.
+// Returns an error if the path is set but the file cannot be read.
+func (a AgentConfig) ResolvePrompt(baseDir string) (string, error) {
+	if strings.TrimSpace(a.SystemPromptPath) == "" {
+		return a.SystemPrompt, nil
+	}
+	path := a.SystemPromptPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read system_prompt_path %q: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// ResolvePrompt returns the resolved prompt for a wake task step.
+// If PromptPath is set, it reads the file (resolved relative to baseDir if not absolute).
+// Otherwise, falls back to inline Prompt.
+func (s WakeTaskStep) ResolvePrompt(baseDir string) (string, error) {
+	if strings.TrimSpace(s.PromptPath) == "" {
+		return s.Prompt, nil
+	}
+	path := s.PromptPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read prompt_path %q: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// LoadAgentFile loads a standalone agent definition from a TOML file.
+// Used for Phase 2 agent directories (~/.config/v100/agents/*.toml).
+func LoadAgentFile(path string) (AgentConfig, error) {
+	var agent AgentConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return agent, fmt.Errorf("read agent file %q: %w", path, err)
+	}
+	if _, err := toml.Decode(string(data), &agent); err != nil {
+		return agent, fmt.Errorf("parse agent file %q: %w", path, err)
+	}
+	return agent, nil
+}
+
+// LoadAgentsDirectory loads all agent definitions from a directory.
+// Each .toml file in the directory is loaded as a separate agent,
+// keyed by the filename (without extension).
+// Returns an empty map (not an error) if the directory does not exist.
+func LoadAgentsDirectory(dir string) (map[string]AgentConfig, error) {
+	agents := map[string]AgentConfig{}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return agents, nil
+		}
+		return nil, fmt.Errorf("read agents directory %q: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".toml") {
+			continue
+		}
+		key := strings.TrimSuffix(name, ".toml")
+		agent, err := LoadAgentFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		agents[key] = agent
+	}
+	return agents, nil
+}

--- a/internal/config/prompt_resolver.go
+++ b/internal/config/prompt_resolver.go
@@ -9,41 +9,48 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// resolvePromptPath reads a prompt from the given path, applying ~ expansion
+// and resolving relative paths against baseDir.
+func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
+	path := expandHome(rawPath)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s %q: %w", field, path, err)
+	}
+	return string(data), nil
+}
+
 // ResolvePrompt returns the resolved system prompt for an agent.
-// If SystemPromptPath is set, it reads the file (resolved relative to baseDir if not absolute).
+// If SystemPromptPath is set, it reads the file. The path may use ~/ for
+// home-relative paths and is otherwise resolved relative to baseDir.
 // Otherwise, falls back to inline SystemPrompt.
 // Returns an error if the path is set but the file cannot be read.
 func (a AgentConfig) ResolvePrompt(baseDir string) (string, error) {
 	if strings.TrimSpace(a.SystemPromptPath) == "" {
 		return a.SystemPrompt, nil
 	}
-	path := a.SystemPromptPath
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(baseDir, path)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read system_prompt_path %q: %w", path, err)
-	}
-	return string(data), nil
+	return resolvePromptPath(a.SystemPromptPath, baseDir, "system_prompt_path")
 }
 
 // ResolvePrompt returns the resolved prompt for a wake task step.
-// If PromptPath is set, it reads the file (resolved relative to baseDir if not absolute).
+// If PromptPath is set, it reads the file. The path may use ~/ for
+// home-relative paths and is otherwise resolved relative to baseDir.
 // Otherwise, falls back to inline Prompt.
 func (s WakeTaskStep) ResolvePrompt(baseDir string) (string, error) {
 	if strings.TrimSpace(s.PromptPath) == "" {
 		return s.Prompt, nil
 	}
-	path := s.PromptPath
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(baseDir, path)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read prompt_path %q: %w", path, err)
-	}
-	return string(data), nil
+	return resolvePromptPath(s.PromptPath, baseDir, "prompt_path")
+}
+
+// XDGConfigDir returns the directory containing the user's v100 config file.
+// Used as the default baseDir for resolving prompt_path / system_prompt_path
+// when callers do not supply one explicitly.
+func XDGConfigDir() string {
+	return filepath.Dir(XDGConfigPath())
 }
 
 // LoadAgentFile loads a standalone agent definition from a TOML file.

--- a/internal/config/prompt_resolver_test.go
+++ b/internal/config/prompt_resolver_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAgentConfig_ResolvePrompt_Inline(t *testing.T) {
+	agent := AgentConfig{SystemPrompt: "inline prompt"}
+	got, err := agent.ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "inline prompt" {
+		t.Errorf("expected inline prompt, got %q", got)
+	}
+}
+
+func TestAgentConfig_ResolvePrompt_FromPath(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "agent.md")
+	if err := os.WriteFile(promptPath, []byte("file prompt content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agent := AgentConfig{SystemPromptPath: "agent.md"}
+	got, err := agent.ResolvePrompt(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "file prompt content" {
+		t.Errorf("expected file content, got %q", got)
+	}
+}
+
+func TestAgentConfig_ResolvePrompt_AbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "agent.md")
+	if err := os.WriteFile(promptPath, []byte("absolute"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agent := AgentConfig{SystemPromptPath: promptPath}
+	got, err := agent.ResolvePrompt("/some/other/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "absolute" {
+		t.Errorf("expected absolute, got %q", got)
+	}
+}
+
+func TestAgentConfig_ResolvePrompt_MissingFile(t *testing.T) {
+	agent := AgentConfig{SystemPromptPath: "nonexistent.md"}
+	_, err := agent.ResolvePrompt(t.TempDir())
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestWakeTaskStep_ResolvePrompt_Inline(t *testing.T) {
+	step := WakeTaskStep{Prompt: "inline step prompt"}
+	got, err := step.ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "inline step prompt" {
+		t.Errorf("expected inline, got %q", got)
+	}
+}
+
+func TestWakeTaskStep_ResolvePrompt_FromPath(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "step.md")
+	if err := os.WriteFile(promptPath, []byte("step from file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	step := WakeTaskStep{PromptPath: "step.md"}
+	got, err := step.ResolvePrompt(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "step from file" {
+		t.Errorf("expected file content, got %q", got)
+	}
+}
+
+func TestLoadAgentFile(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "researcher.toml")
+	content := `system_prompt = "You are a researcher"
+tools = ["fs_read", "web_search"]
+model = "glm-5.1"
+budget_tokens = 50000
+`
+	if err := os.WriteFile(agentPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agent, err := LoadAgentFile(agentPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent.SystemPrompt != "You are a researcher" {
+		t.Errorf("wrong system prompt: %q", agent.SystemPrompt)
+	}
+	if len(agent.Tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(agent.Tools))
+	}
+	if agent.Model != "glm-5.1" {
+		t.Errorf("wrong model: %q", agent.Model)
+	}
+	if agent.BudgetTokens != 50000 {
+		t.Errorf("wrong budget: %d", agent.BudgetTokens)
+	}
+}
+
+func TestLoadAgentFile_WithPromptPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "prompt.md"), []byte("external prompt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agentPath := filepath.Join(dir, "agent.toml")
+	content := `system_prompt_path = "prompt.md"
+tools = ["fs_read"]
+`
+	if err := os.WriteFile(agentPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	agent, err := LoadAgentFile(agentPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	prompt, err := agent.ResolvePrompt(dir)
+	if err != nil {
+		t.Fatalf("resolve error: %v", err)
+	}
+	if prompt != "external prompt" {
+		t.Errorf("expected external prompt, got %q", prompt)
+	}
+}
+
+func TestLoadAgentsDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write two valid agent files
+	files := map[string]string{
+		"researcher.toml": `system_prompt = "research"`,
+		"coder.toml":      `system_prompt = "code"`,
+		"readme.md":       `# This should be ignored`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	agents, err := LoadAgentsDirectory(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Errorf("expected 2 agents, got %d: %v", len(agents), agents)
+	}
+	if agents["researcher"].SystemPrompt != "research" {
+		t.Errorf("missing researcher")
+	}
+	if agents["coder"].SystemPrompt != "code" {
+		t.Errorf("missing coder")
+	}
+}
+
+func TestLoadAgentsDirectory_MissingDir(t *testing.T) {
+	agents, err := LoadAgentsDirectory("/nonexistent/path/that/does/not/exist")
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("expected empty map, got %d agents", len(agents))
+	}
+}

--- a/internal/config/prompt_resolver_test.go
+++ b/internal/config/prompt_resolver_test.go
@@ -177,3 +177,49 @@ func TestLoadAgentsDirectory_MissingDir(t *testing.T) {
 		t.Errorf("expected empty map, got %d agents", len(agents))
 	}
 }
+
+func TestAgentConfig_ResolvePrompt_TildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sub := filepath.Join(home, "promptdir")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "agent.md"), []byte("tilde works"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agent := AgentConfig{SystemPromptPath: "~/promptdir/agent.md"}
+	got, err := agent.ResolvePrompt("/some/other/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "tilde works" {
+		t.Errorf("expected tilde-expanded content, got %q", got)
+	}
+}
+
+func TestWakeTaskStep_ResolvePrompt_TildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "step.md"), []byte("step tilde"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	step := WakeTaskStep{PromptPath: "~/step.md"}
+	got, err := step.ResolvePrompt("/elsewhere")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "step tilde" {
+		t.Errorf("expected tilde-expanded content, got %q", got)
+	}
+}
+
+func TestXDGConfigDir(t *testing.T) {
+	got := XDGConfigDir()
+	if got == "" {
+		t.Error("XDGConfigDir returned empty string")
+	}
+	if filepath.Base(got) != "v100" {
+		t.Errorf("expected last segment v100, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of issue #198 - decouple behavioral logic from infrastructure config.
Adds external file path support for agent and wake task prompts, enabling
markdown editing with syntax highlighting and prompt isolation.

## Changes

- **AgentConfig.SystemPromptPath** — optional path to .md/.txt file containing system prompt
- **WakeTaskStep.PromptPath** — optional path to external prompt file for wake steps  
- **ResolvePrompt() methods** — resolve external paths or fall back to inline prompts
- **LoadAgentFile() / LoadAgentsDirectory()** — Phase 2-ready helpers for ~/.config/v100/agents/

## Behavior

- Path empty → use inline prompt (backward compatible)
- Relative path → resolved against caller's baseDir
- Absolute path → used as-is
- Missing file → error returned

## Tests

10 new unit tests covering:
- Inline prompt fallback for agents and wake steps
- Relative vs absolute path resolution
- Missing file error handling  
- TOML agent file loading
- Directory scanning (ignores non-.toml files, handles missing dirs gracefully)

All passing: \`go test ./internal/config\`

## Test plan
- [x] Unit tests pass
- [x] go build ./internal/... ./cmd/...
- [ ] Manual: agent with system_prompt_path loads correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Agent and task configurations can now reference external prompt files, enabling better separation of configuration from prompt content
* Added support for batch-loading agent configurations from a directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->