### PR TITLE
fix: standardize tool output caps (issue #199)

### DIFF
--- a/internal/tools/atproto.go
+++ b/internal/tools/atproto.go
@@ -123,7 +123,7 @@ func (t *atprotoFeedTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 	if resp.Cursor != "" {
 		fmt.Fprintf(&sb, "cursor: %s", resp.Cursor)
 	}
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +240,7 @@ func (t *atprotoNotificationsTool) Exec(_ context.Context, _ ToolCallContext, ar
 	if count == 0 {
 		return ToolResult{OK: true, Output: "no notifications"}, nil
 	}
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -712,7 +712,7 @@ func (t *atprotoUploadBlobTool) Exec(_ context.Context, _ ToolCallContext, args 
 		"size": blob.Size,
 		"alt":  in.AltText,
 	})
-	return ToolResult{OK: true, Output: string(out)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(out)}), nil
 }
 
 func isSupportedBskyImage(mime string) bool {

--- a/internal/tools/atproto_digest.go
+++ b/internal/tools/atproto_digest.go
@@ -329,7 +329,7 @@ func (t *atprotoEngagementHealthTool) Exec(_ context.Context, _ ToolCallContext,
 	for _, suggestion := range suggestions {
 		fmt.Fprintf(&sb, "- %s\n", suggestion)
 	}
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 func engagementHealthSuggestions(postsPerDay, avgEngagement float64, replyPosts, quoteOrLinkish, totalPosts int) []string {
@@ -443,7 +443,7 @@ func (t *atprotoVibeCheckTool) Exec(_ context.Context, _ ToolCallContext, args j
 			p.AuthorHandle, p.Likes, p.Reposts, p.Replies, p.Text)
 	}
 
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -549,5 +549,5 @@ func (t *atprotoDailyDigestTool) Exec(_ context.Context, _ ToolCallContext, args
 			idx+1, p.AuthorHandle, score, p.Text)
 	}
 
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }

--- a/internal/tools/atproto_graph.go
+++ b/internal/tools/atproto_graph.go
@@ -98,7 +98,7 @@ func (t *atprotoGetFollowsTool) Exec(_ context.Context, _ ToolCallContext, args 
 		return ToolResult{OK: false, Output: err.Error()}, nil
 	}
 
-	return ToolResult{OK: true, Output: string(data)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +171,7 @@ func (t *atprotoGetFollowersTool) Exec(_ context.Context, _ ToolCallContext, arg
 		return ToolResult{OK: false, Output: err.Error()}, nil
 	}
 
-	return ToolResult{OK: true, Output: string(data)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -230,7 +230,7 @@ func (t *atprotoGetProfileTool) Exec(_ context.Context, _ ToolCallContext, args 
 		return ToolResult{OK: false, Output: err.Error()}, nil
 	}
 
-	return ToolResult{OK: true, Output: string(data)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/atproto_rag.go
+++ b/internal/tools/atproto_rag.go
@@ -567,9 +567,9 @@ func (t *atprotoRecallTool) Exec(ctx context.Context, call ToolCallContext, args
 	if err != nil {
 		return failResult(start, "marshal results: "+err.Error()), nil
 	}
-	return ToolResult{
+	return CapToolResult(ToolResult{
 		OK:         true,
 		Output:     string(b),
 		DurationMS: time.Since(start).Milliseconds(),
-	}, nil
+	}), nil
 }

--- a/internal/tools/atproto_synth.go
+++ b/internal/tools/atproto_synth.go
@@ -166,5 +166,5 @@ func (t *atrotoAnonSynthTool) Exec(_ context.Context, _ ToolCallContext, args js
 		"post_count": len(lines),
 		"skipped":    skipped,
 	})
-	return ToolResult{OK: true, Output: string(out)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(out)}), nil
 }

--- a/internal/tools/caps.go
+++ b/internal/tools/caps.go
@@ -22,6 +22,15 @@ const (
 	MaxFetchBytes int64 = 2 * 1024 * 1024
 )
 
+// CapToolResult applies DefaultToolResultChars to a ToolResult's Output and
+// Stdout fields. Convenience wrapper for tools that build large string/JSON
+// outputs and want consistent tool-layer truncation.
+func CapToolResult(r ToolResult) ToolResult {
+	r.Output = TruncateOutput(r.Output, DefaultToolResultChars)
+	r.Stdout = TruncateOutput(r.Stdout, DefaultToolResultChars)
+	return r
+}
+
 // TruncateOutput truncates s to maxChars characters, appending a
 // human-readable suffix indicating how many characters were elided.
 // If maxChars <= 0 or s is already short enough, returns s unchanged.

--- a/internal/tools/caps.go
+++ b/internal/tools/caps.go
@@ -1,0 +1,40 @@
+package tools
+
+import "fmt"
+
+// Default output caps for tools. These are slightly above the policy's
+// MaxToolResultChars default (20000) so the policy's truncation layer
+// has the final say, but tool-layer caps prevent runaway memory/IO
+// from extremely large responses.
+const (
+	// DefaultToolResultChars is the default character cap for tool outputs.
+	// Set slightly above the policy default (20000) to give the loop's
+	// truncation logic the final word while preventing pathological cases.
+	DefaultToolResultChars = 24000
+
+	// DefaultFetchBytes is the default byte cap for HTTP fetches (curl, web_extract).
+	// HTML compresses heavily to text, so we allow more bytes than chars.
+	// Was previously 128KB (6x policy default) — now 64KB (~3x policy default).
+	DefaultFetchBytes int64 = 64 * 1024
+
+	// MaxFetchBytes is the absolute upper bound on HTTP fetch sizes
+	// regardless of caller request. Prevents DoS via large remote responses.
+	MaxFetchBytes int64 = 2 * 1024 * 1024
+)
+
+// TruncateOutput truncates s to maxChars characters, appending a
+// human-readable suffix indicating how many characters were elided.
+// If maxChars <= 0 or s is already short enough, returns s unchanged.
+func TruncateOutput(s string, maxChars int) string {
+	if maxChars <= 0 || len(s) <= maxChars {
+		return s
+	}
+	elided := len(s) - maxChars
+	suffix := fmt.Sprintf("\n…[truncated %d chars]", elided)
+	// If suffix alone exceeds the cap, return a truncated suffix
+	if len(suffix) >= maxChars {
+		return suffix[:maxChars]
+	}
+	cut := maxChars - len(suffix)
+	return s[:cut] + suffix
+}

--- a/internal/tools/caps_test.go
+++ b/internal/tools/caps_test.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateOutput_ShortString(t *testing.T) {
+	s := "hello"
+	got := TruncateOutput(s, 100)
+	if got != s {
+		t.Errorf("expected unchanged, got %q", got)
+	}
+}
+
+func TestTruncateOutput_ExactLength(t *testing.T) {
+	s := strings.Repeat("x", 100)
+	got := TruncateOutput(s, 100)
+	if got != s {
+		t.Errorf("expected unchanged for exact match, got len=%d", len(got))
+	}
+}
+
+func TestTruncateOutput_Truncated(t *testing.T) {
+	s := strings.Repeat("x", 1000)
+	got := TruncateOutput(s, 200)
+	if len(got) != 200 {
+		t.Errorf("expected len 200, got %d", len(got))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("expected truncation marker, got: %q", got[len(got)-50:])
+	}
+	if !strings.Contains(got, "800") {
+		t.Errorf("expected elided count 800, got: %q", got[len(got)-50:])
+	}
+}
+
+func TestTruncateOutput_ZeroMax(t *testing.T) {
+	s := strings.Repeat("x", 1000)
+	got := TruncateOutput(s, 0)
+	if got != s {
+		t.Errorf("max=0 should disable truncation")
+	}
+}
+
+func TestTruncateOutput_NegativeMax(t *testing.T) {
+	s := strings.Repeat("x", 1000)
+	got := TruncateOutput(s, -1)
+	if got != s {
+		t.Errorf("negative max should disable truncation")
+	}
+}
+
+func TestTruncateOutput_TinyMax(t *testing.T) {
+	// max smaller than suffix length should still work without panicking
+	s := strings.Repeat("x", 1000)
+	got := TruncateOutput(s, 10)
+	if len(got) > 10 {
+		t.Errorf("output exceeds max: %d", len(got))
+	}
+}
+
+func TestDefaultCaps_Sanity(t *testing.T) {
+	// Tool-layer chars cap should be slightly above policy default (20000)
+	// but well below pathological sizes
+	if DefaultToolResultChars < 20000 {
+		t.Errorf("DefaultToolResultChars too small: %d", DefaultToolResultChars)
+	}
+	if DefaultToolResultChars > 100000 {
+		t.Errorf("DefaultToolResultChars too large: %d", DefaultToolResultChars)
+	}
+
+	// Default fetch bytes should be moderate (not 128KB which was the old value)
+	if DefaultFetchBytes < 32*1024 {
+		t.Errorf("DefaultFetchBytes too small: %d", DefaultFetchBytes)
+	}
+	if DefaultFetchBytes > 128*1024 {
+		t.Errorf("DefaultFetchBytes too large (regression to old 128KB?): %d", DefaultFetchBytes)
+	}
+
+	// MaxFetchBytes should be much larger (caller can request larger)
+	if MaxFetchBytes <= DefaultFetchBytes {
+		t.Errorf("MaxFetchBytes (%d) should exceed default (%d)", MaxFetchBytes, DefaultFetchBytes)
+	}
+}

--- a/internal/tools/caps_test.go
+++ b/internal/tools/caps_test.go
@@ -60,6 +60,29 @@ func TestTruncateOutput_TinyMax(t *testing.T) {
 	}
 }
 
+func TestCapToolResult_AppliesToOutputAndStdout(t *testing.T) {
+	big := strings.Repeat("x", DefaultToolResultChars*2)
+	r := ToolResult{OK: true, Output: big, Stdout: big}
+	got := CapToolResult(r)
+	if len(got.Output) > DefaultToolResultChars {
+		t.Errorf("Output not capped: len=%d", len(got.Output))
+	}
+	if len(got.Stdout) > DefaultToolResultChars {
+		t.Errorf("Stdout not capped: len=%d", len(got.Stdout))
+	}
+	if !strings.Contains(got.Output, "truncated") {
+		t.Error("expected truncation marker on Output")
+	}
+}
+
+func TestCapToolResult_PreservesShort(t *testing.T) {
+	r := ToolResult{OK: true, Output: "short", Stdout: "short"}
+	got := CapToolResult(r)
+	if got.Output != "short" || got.Stdout != "short" {
+		t.Errorf("short output should pass through unchanged: %+v", got)
+	}
+}
+
 func TestDefaultCaps_Sanity(t *testing.T) {
 	// Tool-layer chars cap should be slightly above policy default (20000)
 	// but well below pathological sizes

--- a/internal/tools/curl.go
+++ b/internal/tools/curl.go
@@ -70,7 +70,7 @@ func (t *curlFetchTool) Exec(ctx context.Context, call ToolCallContext, args jso
 		URL      string `json:"url"`
 		MaxBytes int64  `json:"max_bytes"`
 	}
-	a.MaxBytes = 128 * 1024
+	a.MaxBytes = DefaultFetchBytes
 	if err := json.Unmarshal(args, &a); err != nil {
 		return failResult(start, "invalid args: "+err.Error()), nil
 	}
@@ -81,8 +81,8 @@ func (t *curlFetchTool) Exec(ctx context.Context, call ToolCallContext, args jso
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		return failResult(start, "url must start with http:// or https://"), nil
 	}
-	if a.MaxBytes <= 0 || a.MaxBytes > 2*1024*1024 {
-		a.MaxBytes = 128 * 1024
+	if a.MaxBytes <= 0 || a.MaxBytes > MaxFetchBytes {
+		a.MaxBytes = DefaultFetchBytes
 	}
 	fetched, fail, err := fetchHTTPBody(ctx, call, start, url, a.MaxBytes, false)
 	if err != nil {

--- a/internal/tools/news.go
+++ b/internal/tools/news.go
@@ -346,10 +346,11 @@ func (t *newsFetchTool) Exec(ctx context.Context, call ToolCallContext, args jso
 		return failResult(start, "marshal output: "+err.Error()), nil
 	}
 
+	capped := TruncateOutput(string(body), DefaultToolResultChars)
 	result := ToolResult{
 		OK:         len(items) > 0,
-		Output:     string(body),
-		Stdout:     string(body),
+		Output:     capped,
+		Stdout:     capped,
 		DurationMS: time.Since(start).Milliseconds(),
 	}
 	return sanitizeToolResult(call, result), nil

--- a/internal/tools/sh.go
+++ b/internal/tools/sh.go
@@ -98,15 +98,21 @@ func (t *shTool) Exec(ctx context.Context, call ToolCallContext, args json.RawMe
 		return failResult(start, "exec error: "+err.Error()), nil
 	}
 
+	// Apply tool-layer cap to stdout/stderr before serializing.
+	// The policy's MaxToolResultChars will still apply at the loop level;
+	// this prevents pathological shell output from blowing up memory.
+	cappedStdout := TruncateOutput(res.Stdout, DefaultToolResultChars)
+	cappedStderr := TruncateOutput(res.Stderr, DefaultToolResultChars)
+
 	payload := map[string]any{
-		"stdout":    res.Stdout,
-		"stderr":    res.Stderr,
+		"stdout":    cappedStdout,
+		"stderr":    cappedStderr,
 		"exit_code": res.ExitCode,
 	}
-	if lines := outputLines(res.Stdout); len(lines) > 0 {
+	if lines := outputLines(cappedStdout); len(lines) > 0 {
 		payload["stdout_lines"] = lines
 	}
-	if lines := outputLines(res.Stderr); len(lines) > 0 {
+	if lines := outputLines(cappedStderr); len(lines) > 0 {
 		payload["stderr_lines"] = lines
 	}
 
@@ -117,8 +123,8 @@ func (t *shTool) Exec(ctx context.Context, call ToolCallContext, args json.RawMe
 	return sanitizeToolResult(call, ToolResult{
 		OK:         res.ExitCode == 0,
 		Output:     string(out),
-		Stdout:     res.Stdout,
-		Stderr:     res.Stderr,
+		Stdout:     cappedStdout,
+		Stderr:     cappedStderr,
 		DurationMS: time.Since(start).Milliseconds(),
 	}), nil
 }

--- a/internal/tools/web_extract.go
+++ b/internal/tools/web_extract.go
@@ -51,7 +51,7 @@ func (t *webExtractTool) Exec(ctx context.Context, call ToolCallContext, args js
 		URL      string `json:"url"`
 		MaxBytes int64  `json:"max_bytes"`
 	}
-	a.MaxBytes = 128 * 1024
+	a.MaxBytes = DefaultFetchBytes
 	if err := json.Unmarshal(args, &a); err != nil {
 		return failResult(start, "invalid args: "+err.Error()), nil
 	}
@@ -62,8 +62,8 @@ func (t *webExtractTool) Exec(ctx context.Context, call ToolCallContext, args js
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		return failResult(start, "url must start with http:// or https://"), nil
 	}
-	if a.MaxBytes <= 0 || a.MaxBytes > 2*1024*1024 {
-		a.MaxBytes = 128 * 1024
+	if a.MaxBytes <= 0 || a.MaxBytes > MaxFetchBytes {
+		a.MaxBytes = DefaultFetchBytes
 	}
 
 	fetched, fail, err := fetchHTTPBody(ctx, call, start, url, a.MaxBytes, false)

--- a/internal/tools/wiki.go
+++ b/internal/tools/wiki.go
@@ -161,6 +161,7 @@ func (t *wikiTool) doRead(ctx context.Context, call ToolCallContext, start time.
 
 	output := fmt.Sprintf("title: %s\npageid: %d\nsource: remote\nfetched_at: %s\nlang: %s\n\n%s",
 		article.Title, article.PageID, article.FetchedAt.Format(time.RFC3339), article.Lang, extract)
+	output = TruncateOutput(output, DefaultToolResultChars)
 	return ToolResult{OK: true, Output: output, Stdout: output, DurationMS: time.Since(start).Milliseconds()}, nil
 }
 
@@ -184,6 +185,7 @@ func (t *wikiTool) doSearch(ctx context.Context, call ToolCallContext, start tim
 	}
 
 	output := strings.Join(lines, "\n")
+	output = TruncateOutput(output, DefaultToolResultChars)
 	return ToolResult{OK: true, Output: output, Stdout: output, DurationMS: time.Since(start).Milliseconds()}, nil
 }
 

--- a/internal/tools/wiki.go
+++ b/internal/tools/wiki.go
@@ -137,6 +137,7 @@ func (t *wikiTool) doRead(ctx context.Context, call ToolCallContext, start time.
 			}
 			output := fmt.Sprintf("title: %s\npageid: %d\nsource: cache\nfetched_at: %s\nlang: %s\n\n%s",
 				cached.Title, cached.PageID, cached.FetchedAt.Format(time.RFC3339), cached.Lang, extract)
+			output = TruncateOutput(output, DefaultToolResultChars)
 			return ToolResult{OK: true, Output: output, Stdout: output, DurationMS: time.Since(start).Milliseconds()}, nil
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes issue #199 by introducing a centralized caps module and aligning
tool-layer output caps with the policy's MaxToolResultChars default (20000).

## Changes

**New module:** \`internal/tools/caps.go\`
- \`DefaultToolResultChars = 24000\` — slightly above policy default for headroom
- \`DefaultFetchBytes = 64KB\` — was 128KB (6x policy); now ~3x policy
- \`MaxFetchBytes = 2MB\` — absolute upper bound on HTTP fetches
- \`TruncateOutput(s, maxChars)\` — helper with \`…[truncated N chars]\` marker

**Tools updated:**
- \`curl_fetch\`: 128KB → 64KB default (still 2MB max via caller)
- \`web_extract\`: 128KB → 64KB default
- \`sh\`: now truncates stdout/stderr (was uncapped)
- \`wiki\`: now truncates output on all 3 return paths (was uncapped)
- \`news_fetch\`: now truncates JSON payload (was uncapped)

## Rationale

The issue identified two problems:
1. **curl/web_extract over-cap:** 128KB was 6x the policy default (20000 chars), defeating policy truncation
2. **Uncapped tools:** sh/news/wiki had no tool-layer cap, relying solely on loop truncation

Tool-layer caps are now slightly above policy default so the loop's
truncation logic still has the final say, but pathological outputs are
caught before they hit the loop.

## Test plan
- [x] 7 new unit tests for \`TruncateOutput\` edge cases (\`go test ./internal/tools\`)
- [x] Full \`internal/tools\` test suite passes
- [x] \`internal/core\`, \`internal/config\`, \`internal/policy\` tests still pass
- [x] Clean build: \`go build ./internal/... ./cmd/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)