### PR TITLE
fix: robustify bulk-pass cutoff and bound summary length (issue #204)

### DIFF
--- a/internal/core/bulk_cutoff_test.go
+++ b/internal/core/bulk_cutoff_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tripledoublev/v100/internal/providers"
+)
+
+func makeMsgs(sizes ...int) []providers.Message {
+	out := make([]providers.Message, len(sizes))
+	for i, sz := range sizes {
+		out[i] = providers.Message{Role: "user", Content: strings.Repeat("x", sz)}
+	}
+	return out
+}
+
+func TestComputeBulkCutoff_TooShort(t *testing.T) {
+	// 4 messages = exactly protected tail, no candidates
+	msgs := makeMsgs(100, 100, 100, 100)
+	if got := computeBulkCutoff(msgs); got != 0 {
+		t.Errorf("expected 0 for protected-only history, got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_LongHistory(t *testing.T) {
+	// 10 messages: half = 5, which is fine
+	msgs := makeMsgs(100, 100, 100, 100, 100, 100, 100, 100, 100, 100)
+	if got := computeBulkCutoff(msgs); got != 5 {
+		t.Errorf("expected 5 (half), got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_HalfTooBig(t *testing.T) {
+	// 8 messages: half = 4, but tail must be 4 protected → cutoff = 4 (n-protect = 4)
+	msgs := makeMsgs(100, 100, 100, 100, 100, 100, 100, 100)
+	got := computeBulkCutoff(msgs)
+	if got != 4 {
+		t.Errorf("expected 4 (clamped to n-protect), got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_ShortHistory_NoSignificant(t *testing.T) {
+	// 6 messages, small: half=3 (<4), no significant messages → return 0
+	msgs := makeMsgs(100, 100, 100, 100, 100, 100)
+	if got := computeBulkCutoff(msgs); got != 0 {
+		t.Errorf("expected 0 for short uneventful history, got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_ShortHistory_WithSignificant(t *testing.T) {
+	// 6 messages, half=3, but msg[0] is significant → compress n-protect=2 oldest
+	msgs := makeMsgs(8000, 100, 100, 100, 100, 100)
+	got := computeBulkCutoff(msgs)
+	if got != 2 {
+		t.Errorf("expected 2 (n-protect) when significant message exists, got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_ShortHistory_SignificantInTail(t *testing.T) {
+	// Significant message is in the protected tail → don't compress
+	msgs := makeMsgs(100, 100, 100, 8000, 100, 100)
+	if got := computeBulkCutoff(msgs); got != 0 {
+		t.Errorf("expected 0 when significant message is protected, got %d", got)
+	}
+}
+
+func TestComputeBulkCutoff_Empty(t *testing.T) {
+	if got := computeBulkCutoff(nil); got != 0 {
+		t.Errorf("expected 0 for empty, got %d", got)
+	}
+}
+
+func TestBulkSummaryMaxTokens_Sanity(t *testing.T) {
+	if bulkSummaryMaxTokens < 200 || bulkSummaryMaxTokens > 2000 {
+		t.Errorf("bulkSummaryMaxTokens out of reasonable range: %d", bulkSummaryMaxTokens)
+	}
+}

--- a/internal/core/loop.go
+++ b/internal/core/loop.go
@@ -73,7 +73,57 @@ type Loop struct {
 const (
 	budgetCompressionMinContextTokens = 500
 	budgetCompressionLookaheadSteps   = 4
+
+	// bulkSummaryMaxTokens caps the length of the bulk-pass summary so it
+	// doesn't itself contribute meaningful context pressure (~500 tokens).
+	bulkSummaryMaxTokens = 500
+
+	// bulkProtectRecent is the minimum number of recent messages that must
+	// remain untouched after a bulk compress.
+	bulkProtectRecent = 4
+
+	// bulkSignificantMessageChars marks a message as "significant" — large
+	// enough to justify compression even in a short history.
+	bulkSignificantMessageChars = 4000
 )
+
+// computeBulkCutoff returns how many leading messages should be folded into
+// a single summary on the bulk fallback pass.
+//
+// Behavior:
+//   - For longer histories, take roughly the oldest half (legacy behavior),
+//     but never encroach on the last bulkProtectRecent messages.
+//   - For short histories where half-cutoff is below 4, fall back to including
+//     all but the protected tail if any of the older messages are "significant"
+//     (large content). This prevents giant single messages from slipping
+//     through in short conversations — the issue motivating this change.
+//
+// Returns 0 if there is nothing safe to compress.
+func computeBulkCutoff(msgs []providers.Message) int {
+	n := len(msgs)
+	if n <= bulkProtectRecent {
+		return 0
+	}
+	half := n / 2
+	if half >= 4 {
+		// Preserve legacy behavior: oldest half, but never touch the tail.
+		if half > n-bulkProtectRecent {
+			half = n - bulkProtectRecent
+		}
+		return half
+	}
+	// Short history: check for significant messages outside the protected tail.
+	candidates := n - bulkProtectRecent
+	if candidates <= 0 {
+		return 0
+	}
+	for i := 0; i < candidates; i++ {
+		if len(msgs[i].Content) >= bulkSignificantMessageChars {
+			return candidates
+		}
+	}
+	return 0
+}
 
 func (l *Loop) runHooks(stepID string, stage HookStage) HookResult {
 	// Lazily initialize built-in hooks.
@@ -1310,9 +1360,13 @@ func (l *Loop) compress(ctx context.Context, stepID string, force bool) error {
 	}
 
 	// ── Pass 2: Bulk fallback (oldest-half summarization) ─────────────────
-	cutoff := len(l.Messages) / 2
-	if cutoff < 4 {
-		return nil // too short to compress meaningfully
+	// Choose a cutoff that always leaves at least bulkProtectRecent messages intact.
+	// Falls back to compressing fewer messages in short histories if their total
+	// content is significant, rather than the prior `cutoff < 4` escape hatch
+	// that let giant messages slip through.
+	cutoff := computeBulkCutoff(l.Messages)
+	if cutoff < 1 {
+		return nil // nothing meaningful to compress
 	}
 	toSummarize := l.Messages[:cutoff]
 
@@ -1321,10 +1375,11 @@ func (l *Loop) compress(ctx context.Context, stepID string, force bool) error {
 		Messages: append(
 			[]providers.Message{{
 				Role:    "system",
-				Content: "You are a summarizer. Produce a dense, structured summary of the following conversation segment. Preserve: decisions made, files read/edited, tool results, current task state. Be concise.",
+				Content: "You are a summarizer. Produce a dense, structured summary of the following conversation segment. Preserve: decisions made, files read/edited, tool results, current task state. Keep the summary under 500 tokens (~2000 characters). Use terse bullet points; omit pleasantries and redundant detail.",
 			}},
 			sanitizeCompressionMessages(toSummarize)...,
 		),
+		GenParams: providers.GenParams{MaxTokens: bulkSummaryMaxTokens},
 	}
 	resp, err := cp.Complete(ctx, summaryReq)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes issue #204 by closing two gaps in the bulk-pass compression fallback:

1. **Escape hatch for large messages in short histories** — the old
   \`len(Messages)/2 < 4\` check returned early, letting a single giant
   tool result slip through compression entirely.
2. **Unbounded summary length** — the summary prompt said "be concise"
   but had no hard cap, so summaries could themselves balloon.

## Changes

**New helper:** \`computeBulkCutoff()\`
- Long history → oldest half, clamped to never touch the last 4 messages
- Short history → still compress old messages if any are "significant"
  (\`>= 4000 chars\`), closing the escape hatch
- Returns 0 only when nothing safe to compress

**Summary prompt:** explicit "under 500 tokens (~2000 characters)" instruction
plus terse bullet-point guidance.

**Hard cap:** \`GenParams.MaxTokens = 500\` on the compression request as a
provider-level safety net.

## Constants

- \`bulkSummaryMaxTokens = 500\` — max summary length
- \`bulkProtectRecent = 4\` — minimum messages always preserved
- \`bulkSignificantMessageChars = 4000\` — threshold to trigger short-history compress

## Test plan
- [x] 8 new unit tests for cutoff edge cases (\`go test ./internal/core\`)
- [x] Full \`go test ./internal/...\` passes
- [x] \`make lint\` → 0 issues
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)