### PR TITLE
fix: finish prompt paths and tool caps

### DIFF
--- a/cmd/v100/cmd_wake.go
+++ b/cmd/v100/cmd_wake.go
@@ -1572,7 +1572,10 @@ func runWakeSynthesisTask(ctx context.Context, cfg *config.Config, workspace, pr
 			ModelMetadata: providersModelMetadata(ctx, prov, model),
 		}
 
-		stepPrompt := buildStepPrompt(task, i, step, carryContext)
+		stepPrompt, err := buildStepPrompt(cfg.PromptBaseDir(), task, i, step, carryContext)
+		if err != nil {
+			return runID, nil, fmt.Errorf("step %d (%s): %w", i+1, step.Name, err)
+		}
 
 		if err := loop.Step(ctx, stepPrompt); err != nil {
 			_ = loop.EmitRunError("wake-synthesis", err.Error())
@@ -1638,18 +1641,13 @@ func buildScopedToolRegistry(cfg *config.Config, toolNames ...string) *tools.Reg
 	return reg
 }
 
-func buildStepPrompt(task *config.WakeTask, stepIndex int, step config.WakeTaskStep, carryContext string) string {
+func buildStepPrompt(promptBaseDir string, task *config.WakeTask, stepIndex int, step config.WakeTaskStep, carryContext string) (string, error) {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "Task: %s — Step %d of %d: %s\n", task.Name, stepIndex+1, len(task.Steps), step.Name)
-	// Resolve external prompt_path if set, falling back to inline Prompt.
-	// On read failure, fall back silently to inline so a missing file does not
-	// break wake execution — the runtime warning is left to the caller.
-	stepText := step.Prompt
-	if resolved, err := step.ResolvePrompt(config.XDGConfigDir()); err == nil && resolved != "" {
-		stepText = resolved
-	} else if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: %v (falling back to inline prompt)\n", err)
+	stepText, err := step.ResolvePrompt(promptBaseDir)
+	if err != nil {
+		return "", err
 	}
 	fmt.Fprintf(&b, "%s\n\n", stepText)
 
@@ -1667,7 +1665,7 @@ func buildStepPrompt(task *config.WakeTask, stepIndex int, step config.WakeTaskS
 		b.WriteString("\nEnd your response with:\nSYNTHESIS:\n<your final output>\n")
 	}
 
-	return b.String()
+	return b.String(), nil
 }
 
 func resolveWakeModel(cfg *config.Config, providerName string) string {

--- a/cmd/v100/cmd_wake_test.go
+++ b/cmd/v100/cmd_wake_test.go
@@ -564,6 +564,44 @@ func TestBuildWakeIssuePromptIncludesIssueWorkflow(t *testing.T) {
 	}
 }
 
+func TestBuildStepPromptUsesConfigRelativePromptPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "step.md"), []byte("from file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := &config.WakeTask{Name: "daily", Steps: []config.WakeTaskStep{{Name: "read"}}}
+	step := config.WakeTaskStep{
+		Name:       "read",
+		Prompt:     "inline",
+		PromptPath: "step.md",
+	}
+
+	got, err := buildStepPrompt(dir, task, 0, step, "")
+	if err != nil {
+		t.Fatalf("buildStepPrompt() error = %v", err)
+	}
+	if !strings.Contains(got, "from file") {
+		t.Fatalf("prompt missing file content: %q", got)
+	}
+	if strings.Contains(got, "inline") {
+		t.Fatalf("prompt used inline fallback despite prompt_path: %q", got)
+	}
+}
+
+func TestBuildStepPromptFailsOnMissingPromptPath(t *testing.T) {
+	task := &config.WakeTask{Name: "daily", Steps: []config.WakeTaskStep{{Name: "read"}}}
+	step := config.WakeTaskStep{
+		Name:       "read",
+		Prompt:     "inline",
+		PromptPath: "missing.md",
+	}
+
+	_, err := buildStepPrompt(t.TempDir(), task, 0, step, "")
+	if err == nil {
+		t.Fatal("expected error for missing prompt_path")
+	}
+}
+
 func TestRunHeadlessIssueWorkerPassesWakeBudgetsAndToolCeiling(t *testing.T) {
 	oldExec := wakeExecCommand
 	defer func() { wakeExecCommand = oldExec }()

--- a/cmd/v100/helpers.go
+++ b/cmd/v100/helpers.go
@@ -70,6 +70,18 @@ func validateExecutionSafety(cfg *config.Config, confirmMode string, allowUnsafe
 	return fmt.Errorf("refusing to run with confirmations disabled on the host workspace; enable --sandbox or pass --unsafe to acknowledge the risk")
 }
 
+func resolveAgentSystemPrompt(cfg *config.Config, roleCfg config.AgentConfig) (string, error) {
+	systemPrompt, err := roleCfg.ResolvePrompt(cfg.PromptBaseDir())
+	if err != nil {
+		return "", err
+	}
+	systemPrompt = strings.TrimSpace(systemPrompt)
+	if systemPrompt == "" {
+		systemPrompt = "You are a focused sub-agent. Complete the given task concisely. Use the tools available to you."
+	}
+	return systemPrompt, nil
+}
+
 func buildProvider(cfg *config.Config, providerName string) (providers.Provider, error) {
 	pc, ok := cfg.Providers[providerName]
 	if !ok {
@@ -760,16 +772,9 @@ func registerAgentTool(cfg *config.Config, reg *tools.Registry, trace *core.Trac
 			Dir: workspace,
 		}
 
-		// Resolve sub-agent system prompt, preferring system_prompt_path when set.
-		// Falls back to inline SystemPrompt on read error, then to a default.
-		systemPrompt, err := roleCfg.ResolvePrompt(config.XDGConfigDir())
+		systemPrompt, err := resolveAgentSystemPrompt(cfg, roleCfg)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: %v (falling back to inline system_prompt)\n", err)
-			systemPrompt = roleCfg.SystemPrompt
-		}
-		systemPrompt = strings.TrimSpace(systemPrompt)
-		if systemPrompt == "" {
-			systemPrompt = "You are a focused sub-agent. Complete the given task concisely. Use the tools available to you."
+			return tools.AgentRunResult{OK: false, Result: "resolve agent system prompt: " + err.Error()}
 		}
 		policyName := "sub-agent"
 		if strings.TrimSpace(params.Agent) != "" {

--- a/cmd/v100/helpers_agents_test.go
+++ b/cmd/v100/helpers_agents_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -51,5 +53,40 @@ func TestAgentsCmdListsDefaultRoles(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("agents output missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+func TestResolveAgentSystemPromptUsesConfigSourceDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "agent.md"), []byte("from file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.SourceDir = dir
+	role := config.AgentConfig{
+		SystemPrompt:     "inline",
+		SystemPromptPath: "agent.md",
+	}
+
+	got, err := resolveAgentSystemPrompt(cfg, role)
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt() error = %v", err)
+	}
+	if got != "from file" {
+		t.Fatalf("resolveAgentSystemPrompt() = %q, want file prompt", got)
+	}
+}
+
+func TestResolveAgentSystemPromptFailsOnMissingPromptPath(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SourceDir = t.TempDir()
+	role := config.AgentConfig{
+		SystemPrompt:     "inline",
+		SystemPromptPath: "missing.md",
+	}
+
+	_, err := resolveAgentSystemPrompt(cfg, role)
+	if err == nil {
+		t.Fatal("expected error for missing system_prompt_path")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,10 @@ import (
 
 // Config is the root configuration structure.
 type Config struct {
+	// SourceDir is the directory containing the config file that produced this
+	// Config. It is runtime metadata, not a TOML setting.
+	SourceDir string `toml:"-"`
+
 	Providers  map[string]ProviderConfig `toml:"providers"`
 	Tools      ToolsConfig               `toml:"tools"`
 	Policies   map[string]PolicyConfig   `toml:"policies"`
@@ -176,6 +180,7 @@ type DefaultsConfig struct {
 // DefaultConfig returns a built-in baseline configuration.
 func DefaultConfig() *Config {
 	return &Config{
+		SourceDir: XDGConfigDir(),
 		Providers: map[string]ProviderConfig{
 			"smartrouter": {
 				Type: "smartrouter",
@@ -441,6 +446,7 @@ func Load(path string) (*Config, error) {
 	_ = LoadDotEnv(".env")
 
 	path = expandHome(path)
+	sourceDir := configSourceDir(path)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
@@ -450,6 +456,7 @@ func Load(path string) (*Config, error) {
 	if _, err := toml.Decode(string(data), &cfg); err != nil {
 		return nil, fmt.Errorf("config: parse %s: %w", path, err)
 	}
+	cfg.SourceDir = sourceDir
 	applyProviderDefaults(&cfg, DefaultConfig())
 	applyToolDefaults(&cfg.Tools, DefaultConfig().Tools)
 	// Backward-compatible tool migrations for older config files.

--- a/internal/config/prompt_resolver.go
+++ b/internal/config/prompt_resolver.go
@@ -14,6 +14,9 @@ import (
 func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
 	path := expandHome(rawPath)
 	if !filepath.IsAbs(path) {
+		if strings.TrimSpace(baseDir) == "" {
+			baseDir = XDGConfigDir()
+		}
 		path = filepath.Join(baseDir, path)
 	}
 	data, err := os.ReadFile(path)
@@ -21,6 +24,25 @@ func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
 		return "", fmt.Errorf("read %s %q: %w", field, path, err)
 	}
 	return string(data), nil
+}
+
+// PromptBaseDir returns the directory relative prompt paths should resolve
+// against for this config.
+func (c *Config) PromptBaseDir() string {
+	if c != nil && strings.TrimSpace(c.SourceDir) != "" {
+		return c.SourceDir
+	}
+	return XDGConfigDir()
+}
+
+func configSourceDir(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return XDGConfigDir()
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Dir(path)
 }
 
 // ResolvePrompt returns the resolved system prompt for an agent.

--- a/internal/config/prompt_resolver_test.go
+++ b/internal/config/prompt_resolver_test.go
@@ -84,6 +84,23 @@ func TestWakeTaskStep_ResolvePrompt_FromPath(t *testing.T) {
 	}
 }
 
+func TestConfigPromptBaseDirFromLoadedConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[defaults]
+provider = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.PromptBaseDir(); got != dir {
+		t.Fatalf("PromptBaseDir() = %q, want %q", got, dir)
+	}
+}
+
 func TestLoadAgentFile(t *testing.T) {
 	dir := t.TempDir()
 	agentPath := filepath.Join(dir, "researcher.toml")

--- a/internal/tools/atproto.go
+++ b/internal/tools/atproto.go
@@ -350,7 +350,7 @@ func (t *atprotoCreateRecordTool) Exec(_ context.Context, _ ToolCallContext, arg
 		CID string `json:"cid"`
 	}
 	if err := json.Unmarshal(data, &out); err != nil {
-		return ToolResult{OK: true, Output: string(data)}, nil
+		return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 	}
 	result, _ := json.Marshal(map[string]any{
 		"ok":         true,
@@ -359,7 +359,7 @@ func (t *atprotoCreateRecordTool) Exec(_ context.Context, _ ToolCallContext, arg
 		"collection": in.Collection,
 		"repo":       cli.session.DID,
 	})
-	return ToolResult{OK: true, Output: string(result)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: string(result)}), nil
 }
 
 func (t *atprotoPostTool) InputSchema() json.RawMessage {
@@ -444,9 +444,9 @@ func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 			CID string `json:"cid"`
 		}
 		if err := json.Unmarshal(data, &out); err != nil {
-			return ToolResult{OK: true, Output: string(data)}, nil
+			return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 		}
-		return ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}, nil
+		return CapToolResult(ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}), nil
 	}
 
 	if in.Text == "" && len(in.Images) == 0 {
@@ -540,9 +540,9 @@ func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 		CID string `json:"cid"`
 	}
 	if err := json.Unmarshal(data, &out); err != nil {
-		return ToolResult{OK: true, Output: string(data)}, nil
+		return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
 	}
-	return ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}, nil
+	return CapToolResult(ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/atproto_graph.go
+++ b/internal/tools/atproto_graph.go
@@ -431,7 +431,7 @@ func (t *atprotoGraphExplorerTool) Exec(_ context.Context, _ ToolCallContext, ar
 			i+1, profileInfo[s.DID], s.Count)
 	}
 
-	return ToolResult{OK: true, Output: sb.String()}, nil
+	return CapToolResult(ToolResult{OK: true, Output: sb.String()}), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -620,7 +620,7 @@ func (t *atprotoCommunityDetectTool) Exec(_ context.Context, _ ToolCallContext, 
 		}
 	}
 
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 func countFollowOccurrences(follows map[string]string) map[string]int {
@@ -793,7 +793,7 @@ func (t *atprotoFollowerMomentumTool) Exec(_ context.Context, _ ToolCallContext,
 	fmt.Fprintf(&sb, "followers fetched: %d · previous snapshot: %d · new: %d\n", len(followers), len(previous), len(newFollowers))
 	if len(newFollowers) == 0 {
 		fmt.Fprintf(&sb, "No new followers since the last snapshot.")
-		return ToolResult{OK: true, Output: sb.String()}, nil
+		return CapToolResult(ToolResult{OK: true, Output: sb.String()}), nil
 	}
 	fmt.Fprintf(&sb, "new follower topics: %s\n\n", strings.Join(topFollowerBioWords(newFollowers, 8), ", "))
 	for idx, follower := range newFollowers {
@@ -811,7 +811,7 @@ func (t *atprotoFollowerMomentumTool) Exec(_ context.Context, _ ToolCallContext,
 		}
 		fmt.Fprintln(&sb)
 	}
-	return ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}, nil
+	return CapToolResult(ToolResult{OK: true, Output: strings.TrimRight(sb.String(), "\n")}), nil
 }
 
 type followerMomentumProfile struct {

--- a/internal/tools/caps_test.go
+++ b/internal/tools/caps_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -104,5 +105,44 @@ func TestDefaultCaps_Sanity(t *testing.T) {
 	// MaxFetchBytes should be much larger (caller can request larger)
 	if MaxFetchBytes <= DefaultFetchBytes {
 		t.Errorf("MaxFetchBytes (%d) should exceed default (%d)", MaxFetchBytes, DefaultFetchBytes)
+	}
+}
+
+func TestFetchInputSchemasAdvertiseDefaultFetchBytes(t *testing.T) {
+	for name, schema := range map[string]json.RawMessage{
+		"curl_fetch":  CurlFetch().InputSchema(),
+		"web_extract": WebExtract().InputSchema(),
+	} {
+		var parsed struct {
+			Properties map[string]struct {
+				Default int64 `json:"default"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(schema, &parsed); err != nil {
+			t.Fatalf("%s schema invalid: %v", name, err)
+		}
+		if got := parsed.Properties["max_bytes"].Default; got != DefaultFetchBytes {
+			t.Fatalf("%s max_bytes default = %d, want %d", name, got, DefaultFetchBytes)
+		}
+	}
+}
+
+func TestMarshalShellResultCapsSerializedOutput(t *testing.T) {
+	out, stdout, stderr, err := marshalShellResult(strings.Repeat("x", DefaultToolResultChars*3), "", 0)
+	if err != nil {
+		t.Fatalf("marshalShellResult() error = %v", err)
+	}
+	if len(out) > DefaultToolResultChars {
+		t.Fatalf("serialized output length = %d, want <= %d", len(out), DefaultToolResultChars)
+	}
+	if len(stdout) > DefaultToolResultChars {
+		t.Fatalf("stdout length = %d, want <= %d", len(stdout), DefaultToolResultChars)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("serialized shell output is not valid JSON: %v\n%s", err, out)
 	}
 }

--- a/internal/tools/curl.go
+++ b/internal/tools/curl.go
@@ -41,14 +41,14 @@ func (t *curlFetchTool) Effects() ToolEffects {
 }
 
 func (t *curlFetchTool) InputSchema() json.RawMessage {
-	return json.RawMessage(`{
+	return json.RawMessage(fmt.Sprintf(`{
 		"type": "object",
 		"required": ["url"],
 		"properties": {
 			"url": {"type": "string", "description": "HTTP or HTTPS URL to fetch."},
-			"max_bytes": {"type": "integer", "description": "Maximum bytes to read from response body.", "default": 131072}
+			"max_bytes": {"type": "integer", "description": "Maximum bytes to read from response body.", "default": %d}
 		}
-	}`)
+	}`, DefaultFetchBytes))
 }
 
 func (t *curlFetchTool) OutputSchema() json.RawMessage {

--- a/internal/tools/sh.go
+++ b/internal/tools/sh.go
@@ -98,35 +98,24 @@ func (t *shTool) Exec(ctx context.Context, call ToolCallContext, args json.RawMe
 		return failResult(start, "exec error: "+err.Error()), nil
 	}
 
-	// Apply tool-layer cap to stdout/stderr before serializing.
-	// The policy's MaxToolResultChars will still apply at the loop level;
-	// this prevents pathological shell output from blowing up memory.
-	cappedStdout := TruncateOutput(res.Stdout, DefaultToolResultChars)
-	cappedStderr := TruncateOutput(res.Stderr, DefaultToolResultChars)
-
-	payload := map[string]any{
-		"stdout":    cappedStdout,
-		"stderr":    cappedStderr,
-		"exit_code": res.ExitCode,
-	}
-	if lines := outputLines(cappedStdout); len(lines) > 0 {
-		payload["stdout_lines"] = lines
-	}
-	if lines := outputLines(cappedStderr); len(lines) > 0 {
-		payload["stderr_lines"] = lines
+	stdout := res.Stdout
+	stderr := res.Stderr
+	if call.Mapper != nil {
+		stdout = call.Mapper.SanitizeText(stdout)
+		stderr = call.Mapper.SanitizeText(stderr)
 	}
 
-	out, err := json.Marshal(payload)
+	out, cappedStdout, cappedStderr, err := marshalShellResult(stdout, stderr, res.ExitCode)
 	if err != nil {
 		return failResult(start, "marshal result: "+err.Error()), nil
 	}
-	return sanitizeToolResult(call, ToolResult{
+	return ToolResult{
 		OK:         res.ExitCode == 0,
 		Output:     string(out),
 		Stdout:     cappedStdout,
 		Stderr:     cappedStderr,
 		DurationMS: time.Since(start).Milliseconds(),
-	}), nil
+	}, nil
 }
 
 func outputLines(s string) []string {
@@ -136,6 +125,71 @@ func outputLines(s string) []string {
 		return nil
 	}
 	return strings.Split(s, "\n")
+}
+
+func marshalShellResult(stdout, stderr string, exitCode int) ([]byte, string, string, error) {
+	streamBudget := DefaultToolResultChars - 2048
+	if streamBudget < 1024 {
+		streamBudget = DefaultToolResultChars / 2
+	}
+	stdoutBudget, stderrBudget := splitShellStreamBudget(len(stdout), len(stderr), streamBudget)
+	includeLines := len(stdout)+len(stderr) <= 4096
+
+	for {
+		cappedStdout := TruncateOutput(stdout, stdoutBudget)
+		cappedStderr := TruncateOutput(stderr, stderrBudget)
+		payload := map[string]any{
+			"stdout":    cappedStdout,
+			"stderr":    cappedStderr,
+			"exit_code": exitCode,
+		}
+		if includeLines {
+			if lines := outputLines(cappedStdout); len(lines) > 0 {
+				payload["stdout_lines"] = lines
+			}
+			if lines := outputLines(cappedStderr); len(lines) > 0 {
+				payload["stderr_lines"] = lines
+			}
+		}
+
+		out, err := json.Marshal(payload)
+		if err != nil {
+			return nil, "", "", err
+		}
+		if len(out) <= DefaultToolResultChars {
+			return out, cappedStdout, cappedStderr, nil
+		}
+		if includeLines {
+			includeLines = false
+			continue
+		}
+		if stdoutBudget <= 128 && stderrBudget <= 128 {
+			return out, cappedStdout, cappedStderr, nil
+		}
+		stdoutBudget = shrinkShellStreamBudget(stdoutBudget)
+		stderrBudget = shrinkShellStreamBudget(stderrBudget)
+	}
+}
+
+func splitShellStreamBudget(stdoutLen, stderrLen, budget int) (int, int) {
+	if stdoutLen == 0 {
+		return 0, budget
+	}
+	if stderrLen == 0 {
+		return budget, 0
+	}
+	return budget / 2, budget - budget/2
+}
+
+func shrinkShellStreamBudget(budget int) int {
+	if budget <= 128 {
+		return budget
+	}
+	next := budget / 2
+	if next < 128 {
+		return 128
+	}
+	return next
 }
 
 const sanitizedShellWrapperScript = `

--- a/internal/tools/web_extract.go
+++ b/internal/tools/web_extract.go
@@ -22,14 +22,14 @@ func (t *webExtractTool) Effects() ToolEffects {
 }
 
 func (t *webExtractTool) InputSchema() json.RawMessage {
-	return json.RawMessage(`{
+	return json.RawMessage(fmt.Sprintf(`{
 		"type": "object",
 		"required": ["url"],
 		"properties": {
 			"url": {"type": "string", "description": "HTTP or HTTPS URL to fetch."},
-			"max_bytes": {"type": "integer", "description": "Maximum bytes to read from response body.", "default": 131072}
+			"max_bytes": {"type": "integer", "description": "Maximum bytes to read from response body.", "default": %d}
 		}
-	}`)
+	}`, DefaultFetchBytes))
 }
 
 func (t *webExtractTool) OutputSchema() json.RawMessage {


### PR DESCRIPTION
## Summary
- resolve prompt_path/system_prompt_path relative to the loaded config file directory and fail on unreadable prompt files instead of silently falling back
- cap remaining atproto tool outputs and keep sh serialized output within the tool-layer cap while preserving valid JSON
- sync curl_fetch/web_extract schemas with DefaultFetchBytes

## Tests
- env GOCACHE=/tmp/v100-followup-gocache go test ./internal/config ./cmd/v100 ./internal/tools -run 'Test.*Prompt|TestConfigPromptBaseDir|TestResolveAgentSystemPrompt|TestBuildStepPrompt|TestFetchInputSchemas|TestMarshalShellResult|Test.*Cap|Test.*Trunc' -count=1
- ./scripts/test.sh
- ./scripts/lint.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and messaging when prompt files fail to load
  * Enhanced system prompt resolution with better error reporting during agent execution

* **Improvements**
  * More intelligent handling of shell command output formatting and character limits
  * Refined configuration directory resolution for prompt files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->