### PR TITLE
fix: use conservative token estimation ratio

### DIFF
--- a/internal/core/context_test.go
+++ b/internal/core/context_test.go
@@ -135,12 +135,12 @@ func TestCharsToTokens(t *testing.T) {
 	}{
 		{0, 0},
 		{-1, 0},
-		{1, 1},    // (10+32)/33 = 1
-		{3, 1},    // (30+32)/33 = 1
-		{4, 2},    // (40+32)/33 = 2 → actually (72)/33 = 2
-		{33, 10},  // (330+32)/33 = 10
-		{100, 31}, // (1000+32)/33 = 31
-		{330, 100},// (3300+32)/33 = 101 → hmm, let me recalc: 3332/33 = 100.96 → 100
+		{1, 1},
+		{2, 1},
+		{3, 2},
+		{27, 10},
+		{100, 38},
+		{270, 100},
 	}
 	for _, tt := range tests {
 		got := charsToTokens(tt.input)
@@ -246,12 +246,21 @@ func TestEstimateTokens(t *testing.T) {
 
 func TestEstimateTokensConsistency(t *testing.T) {
 	// Verify that the ceiling-division formula is consistent: for a given string,
-	// the result should be >= floor(len/3.3) and <= ceil(len/3.3).
-	for _, length := range []int{1, 10, 33, 50, 100, 500, 1000} {
+	// the result should be near ceil(len/2.7), matching the structured-data ratio.
+	for _, length := range []int{1, 10, 27, 50, 100, 500, 1000} {
 		tokens := charsToTokens(length)
-		lower := float64(length) / 3.3
+		lower := float64(length) / 2.7
 		if float64(tokens) < lower-1 || float64(tokens) > lower+1 {
 			t.Errorf("charsToTokens(%d) = %d, expected near %.1f", length, tokens, lower)
 		}
+	}
+}
+
+func TestCharsToTokensStructuredDataRatio(t *testing.T) {
+	if got := charsToTokens(2700); got != 1000 {
+		t.Fatalf("charsToTokens(2700) = %d, want 1000 for 2.7 chars/token", got)
+	}
+	if got := charsToTokens(3300); got <= 1000 {
+		t.Fatalf("charsToTokens(3300) = %d, want > 1000 to avoid old 3.3 chars/token under-estimate", got)
 	}
 }

--- a/internal/core/loop.go
+++ b/internal/core/loop.go
@@ -1063,8 +1063,9 @@ func (l *Loop) toolResultCharLimit(stepID string) int {
 	tokenBudget := remaining - reserve
 	dynamicLimit := 400 // always preserve enough signal for head+tail truncation
 	if tokenBudget > 0 {
-		// estimateTokensSingle uses ~3.3 chars/token; round down conservatively.
-		dynamicLimit = tokenBudget * 3
+		// estimateTokensSingle uses a conservative ~2.7 chars/token
+		// heuristic; round down to preserve provider headroom.
+		dynamicLimit = tokenBudget * 2
 		if dynamicLimit < 400 {
 			dynamicLimit = 400
 		}
@@ -1086,14 +1087,18 @@ func (l *Loop) providerAwareEvidenceThreshold() int {
 	return 0
 }
 
+const (
+	tokenEstimateCharsPerTokenNumerator   = 27
+	tokenEstimateCharsPerTokenDenominator = 10
+)
+
 // charsToTokens converts a byte length to an estimated token count using
-// the ~3.3 chars/token heuristic with ceiling division.
+// a conservative ~2.7 chars/token heuristic with ceiling division.
 func charsToTokens(charLen int) int {
 	if charLen <= 0 {
 		return 0
 	}
-	// Ceiling division: (charLen + 3.3 - 1) / 3.3 ≈ (charLen*10 + 32) / 33
-	return (charLen*10 + 32) / 33
+	return (charLen*tokenEstimateCharsPerTokenDenominator + tokenEstimateCharsPerTokenNumerator - 1) / tokenEstimateCharsPerTokenNumerator
 }
 
 // estimateTokensSingle returns the estimated token count for a single message.
@@ -1123,7 +1128,7 @@ func estimateTokensSingle(m providers.Message) int {
 }
 
 // EstimateTokens returns an estimated token count for a message slice.
-// Uses ~3.3 chars/token with ceiling division, plus per-message framing
+// Uses ~2.7 chars/token with ceiling division, plus per-message framing
 // overhead, tool call structure tokens, and image attachment estimates.
 func EstimateTokens(msgs []providers.Message) int {
 	n := 0

--- a/internal/core/loop_test.go
+++ b/internal/core/loop_test.go
@@ -501,6 +501,7 @@ func TestLoopInspectionWatchdogInjectsSynthesisMessage(t *testing.T) {
 	}
 	loop, trace := newTestLoop(t, prov, []string{"fs_list"})
 	defer func() { _ = trace.Close() }()
+	loop.Budget = core.NewBudgetTracker(&core.Budget{MaxSteps: 10, MaxTokens: 1_000_000})
 
 	if err := loop.Step(context.Background(), "inspect"); err != nil {
 		t.Fatal(err)

--- a/internal/ui/helpers.go
+++ b/internal/ui/helpers.go
@@ -139,15 +139,14 @@ func TruncateOutput(s string, verbose bool) string {
 	return strings.ReplaceAll(s, "\n", " ↵ ")
 }
 
-// estimateTokens estimates token count from string length using ~3.3 chars/token ratio.
+// estimateTokens estimates token count from string length using ~2.7 chars/token ratio.
 // This is a rough estimate; actual token counts vary by model and content.
 // Uses ceiling division for consistency with internal/core token estimation.
 func estimateTokens(s string) int {
 	if s == "" {
 		return 0
 	}
-	// Ceiling division: (len(s) + 3.3 - 1) / 3.3 ≈ (len(s)*10 + 32) / 33
-	tokens := (len(s)*10 + 32) / 33
+	tokens := (len(s)*10 + 26) / 27
 	if tokens == 0 {
 		tokens = 1
 	}


### PR DESCRIPTION
## Summary
- move core message token estimation from the old ~3.3 chars/token heuristic to ~2.7 chars/token
- update the TUI helper to display estimates using the same conservative ratio
- add regression coverage proving 2700 chars maps to 1000 tokens and the old 3.3-ratio under-estimate does not return
- isolate the watchdog synthesis test from unrelated budget-compression pressure caused by the more conservative estimate

Fixes #203

## Tests
- make lint
- make test
- make build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined token estimation algorithms for improved accuracy in context management and tool-result handling decisions.

* **Tests**
  * Enhanced test coverage for token estimation behavior validation across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->