### PR TITLE
fix: repair router model routing and sh verification

### DIFF
--- a/cmd/v100/helpers.go
+++ b/cmd/v100/helpers.go
@@ -393,7 +393,7 @@ func buildSolver(cfg *config.Config, solverName string) (core.Solver, error) {
 		if err != nil {
 			return nil, fmt.Errorf("build smart provider %q: %w", smartProvName, err)
 		}
-		return &core.RouterSolver{Cheap: cheap, Smart: smart}, nil
+		return &core.RouterSolver{Cheap: cheap, Smart: smart, DisplayName: solverName}, nil
 	case "miniglm":
 		minimax, err := buildProvider(cfg, "minimax")
 		if err != nil {
@@ -426,16 +426,10 @@ func buildSolver(cfg *config.Config, solverName string) (core.Solver, error) {
 }
 
 func solverDisplayName(s core.Solver) string {
-	switch s.(type) {
-	case *core.PlanExecuteSolver:
-		return "plan_execute"
-	case *core.RouterSolver:
-		return "smartrouter"
-	case *core.MiniGLMSolver:
-		return "miniglm"
-	default:
+	if s == nil {
 		return "react"
 	}
+	return s.Name()
 }
 
 func buildToolRegistry(cfg *config.Config) *tools.Registry {

--- a/cmd/v100/interactive_mode_test.go
+++ b/cmd/v100/interactive_mode_test.go
@@ -120,6 +120,9 @@ func TestBuildSolverAutoUsesSmartRouterWhenProviderDefaultIsSmartRouter(t *testi
 	if _, ok := solver.(*core.RouterSolver); !ok {
 		t.Fatalf("solver type = %T, want *core.RouterSolver", solver)
 	}
+	if solver.Name() != "smartrouter" {
+		t.Fatalf("solver name = %q, want smartrouter", solver.Name())
+	}
 }
 
 func TestBuildSolverRouterUsesConfiguredCheapProvider(t *testing.T) {
@@ -144,6 +147,9 @@ func TestBuildSolverRouterUsesConfiguredCheapProvider(t *testing.T) {
 	}
 	if router.Cheap.Name() != "glm" {
 		t.Fatalf("cheap provider = %q, want glm", router.Cheap.Name())
+	}
+	if router.Name() != "router" {
+		t.Fatalf("router name = %q, want router", router.Name())
 	}
 }
 

--- a/internal/core/loop.go
+++ b/internal/core/loop.go
@@ -592,14 +592,45 @@ func (l *Loop) execToolCall(ctx context.Context, stepID string, tc providers.Too
 		Name:       tc.Name,
 	})
 
-	// Feedback Loop: Auto-verify build if tool mutated workspace
-	if result.OK && tool.Effects().MutatesWorkspace {
+	// Feedback Loop: Auto-verify build if tool likely mutated workspace.
+	// The sh tool is conservatively marked mutating because it can edit files,
+	// but many shell invocations are read-only; avoid false compile alerts for
+	// commands such as `seq`, `true`, or `grep`.
+	if result.OK && shouldVerifyBuildAfterTool(tool, tc.Args) {
 		// verifyBuild handles its own event emission and message injection.
 		// Ignore the returned error so the loop can continue with the injected alert context.
 		_ = l.verifyBuild(ctx, stepID)
 	}
 
 	return false, nil
+}
+
+func shouldVerifyBuildAfterTool(tool tools.Tool, args json.RawMessage) bool {
+	if tool == nil || !tool.Effects().MutatesWorkspace {
+		return false
+	}
+	if tool.Name() != "sh" {
+		return true
+	}
+	var payload struct {
+		Cmd string `json:"cmd"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return true
+	}
+	cmd := strings.ToLower(payload.Cmd)
+	mutatingMarkers := []string{
+		">", "tee ", "touch ", "mkdir ", "mv ", "cp ", "rm ",
+		"sed -i", "perl -pi", "git apply", "git checkout", "git merge",
+		"git cherry-pick", "go generate", "npm install", "pnpm install",
+		"yarn install", "cargo update",
+	}
+	for _, marker := range mutatingMarkers {
+		if strings.Contains(cmd, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func toolRequiresNetworkGate(tool tools.Tool, session executor.Session) bool {
@@ -628,11 +659,17 @@ func (l *Loop) verifyBuild(ctx context.Context, stepID string) error {
 
 	// Run go build ./...
 	args, _ := json.Marshal(map[string]string{"cmd": "go build ./..."})
+	hostWorkspaceDir := l.Run.Dir
+	if l.Mapper != nil && strings.TrimSpace(l.Mapper.HostRoot) != "" {
+		hostWorkspaceDir = l.Mapper.HostRoot
+	}
 	res, err := sh.Exec(ctx, tools.ToolCallContext{
-		RunID:        l.Run.ID,
-		StepID:       stepID,
-		WorkspaceDir: l.Run.Dir,
-		Mapper:       l.Mapper,
+		RunID:            l.Run.ID,
+		StepID:           stepID,
+		WorkspaceDir:     l.Run.Dir,
+		HostWorkspaceDir: hostWorkspaceDir,
+		Session:          l.Session,
+		Mapper:           l.Mapper,
 	}, args)
 
 	if err == nil && !res.OK {

--- a/internal/core/solver_router.go
+++ b/internal/core/solver_router.go
@@ -37,11 +37,27 @@ func routerToolNeedsEscalation(l *Loop, toolName string) bool {
 
 // RouterSolver dynamically switches between a cheap and a smart provider.
 type RouterSolver struct {
-	Cheap providers.Provider
-	Smart providers.Provider
+	Cheap       providers.Provider
+	Smart       providers.Provider
+	DisplayName string
 }
 
-func (s *RouterSolver) Name() string { return "router" }
+func (s *RouterSolver) Name() string {
+	if strings.TrimSpace(s.DisplayName) != "" {
+		return s.DisplayName
+	}
+	return "router"
+}
+
+func routerRequestModel(l *Loop, p providers.Provider) string {
+	if l == nil || p == nil || l.Provider == nil {
+		return ""
+	}
+	if p.Name() == l.Provider.Name() {
+		return l.Model
+	}
+	return ""
+}
 
 func (s *RouterSolver) Solve(ctx context.Context, l *Loop, userInput string) (SolveResult, error) {
 	stepID := newID()
@@ -109,7 +125,7 @@ func (s *RouterSolver) Solve(ctx context.Context, l *Loop, userInput string) (So
 			StepID:    stepID,
 			Messages:  msgs,
 			Tools:     toolSpecs,
-			Model:     l.Model,
+			Model:     routerRequestModel(l, currentProv),
 			GenParams: l.GenParams,
 			Hints: providers.Hints{
 				MaxToolCalls: maxToolCalls - toolCallsUsed,
@@ -147,7 +163,7 @@ func (s *RouterSolver) Solve(ctx context.Context, l *Loop, userInput string) (So
 				StepID:    stepID,
 				Messages:  msgs,
 				Tools:     toolSpecs,
-				Model:     l.Model,
+				Model:     routerRequestModel(l, currentProv),
 				GenParams: l.GenParams,
 				Hints: providers.Hints{
 					MaxToolCalls: maxToolCalls - toolCallsUsed,

--- a/internal/core/solver_router_test.go
+++ b/internal/core/solver_router_test.go
@@ -43,6 +43,13 @@ func newRouterTestLoop(t *testing.T, cheap, smart providers.Provider, enabledToo
 	}
 }
 
+type namedRouterProvider struct {
+	MockProvider
+	name string
+}
+
+func (p *namedRouterProvider) Name() string { return p.name }
+
 func TestRouterSolverKeepsFSMkdirOnCheapTier(t *testing.T) {
 	ctx := context.Background()
 	cheap := &MockProvider{
@@ -74,6 +81,50 @@ func TestRouterSolverKeepsFSMkdirOnCheapTier(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(loop.Run.Dir, "subdir")); err != nil {
 		t.Fatalf("expected fs_mkdir to run on cheap tier: %v", err)
+	}
+}
+
+func TestRouterSolverUsesActiveModelOnlyForMatchingProvider(t *testing.T) {
+	ctx := context.Background()
+	cheap := &namedRouterProvider{
+		name: "cheap",
+		MockProvider: MockProvider{
+			Responses: []providers.CompleteResponse{{
+				AssistantText: "Escalate unknown tool.",
+				ToolCalls: []providers.ToolCall{
+					{ID: "call_1", Name: "unknown_tool", Args: json.RawMessage(`{}`)},
+				},
+			}},
+		},
+	}
+	smart := &namedRouterProvider{
+		name: "smart",
+		MockProvider: MockProvider{
+			Responses: []providers.CompleteResponse{{AssistantText: "Smart answer."}},
+		},
+	}
+	loop := newRouterTestLoop(t, cheap, smart, nil)
+	loop.Provider = smart
+	loop.Model = "smart-model"
+
+	res, err := loop.Solver.Solve(ctx, loop, "Handle the issue")
+	if err != nil {
+		t.Fatalf("Solve() error = %v", err)
+	}
+	if res.FinalText != "Smart answer." {
+		t.Fatalf("FinalText = %q, want smart answer", res.FinalText)
+	}
+	if len(cheap.Requests) != 1 {
+		t.Fatalf("cheap requests = %d, want 1", len(cheap.Requests))
+	}
+	if cheap.Requests[0].Model != "" {
+		t.Fatalf("cheap request model = %q, want empty provider default", cheap.Requests[0].Model)
+	}
+	if len(smart.Requests) != 1 {
+		t.Fatalf("smart requests = %d, want 1", len(smart.Requests))
+	}
+	if smart.Requests[0].Model != "smart-model" {
+		t.Fatalf("smart request model = %q, want active model", smart.Requests[0].Model)
 	}
 }
 

--- a/internal/core/verify_build_test.go
+++ b/internal/core/verify_build_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/tripledoublev/v100/internal/core/executor"
+	"github.com/tripledoublev/v100/internal/tools"
+)
+
+type recordingSession struct {
+	calls int
+}
+
+func TestShouldVerifyBuildAfterShellReadOnlyCommand(t *testing.T) {
+	args, err := json.Marshal(map[string]string{"cmd": "seq 1 12000"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shouldVerifyBuildAfterTool(tools.Sh(), args) {
+		t.Fatal("read-only shell command should not trigger build verification")
+	}
+}
+
+func TestShouldVerifyBuildAfterShellMutatingCommand(t *testing.T) {
+	args, err := json.Marshal(map[string]string{"cmd": "printf hi > note.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !shouldVerifyBuildAfterTool(tools.Sh(), args) {
+		t.Fatal("mutating shell command should trigger build verification")
+	}
+}
+
+func (s *recordingSession) ID() string                  { return "recording" }
+func (s *recordingSession) Type() string                { return "host" }
+func (s *recordingSession) Start(context.Context) error { return nil }
+func (s *recordingSession) Close() error                { return nil }
+func (s *recordingSession) Workspace() string           { return "" }
+func (s *recordingSession) Run(_ context.Context, _ executor.RunRequest) (executor.Result, error) {
+	s.calls++
+	return executor.Result{ExitCode: 0}, nil
+}
+
+func TestVerifyBuildUsesActiveSession(t *testing.T) {
+	runDir := t.TempDir()
+	reg := tools.NewRegistry([]string{"sh"})
+	reg.Register(tools.Sh())
+	session := &recordingSession{}
+
+	loop := &Loop{
+		Run:     &Run{ID: "verify-build-test", Dir: runDir, TraceFile: filepath.Join(runDir, "trace.jsonl")},
+		Tools:   reg,
+		Session: session,
+		Mapper:  NewPathMapper(runDir, runDir),
+	}
+
+	if err := loop.verifyBuild(context.Background(), "step-1"); err != nil {
+		t.Fatalf("verifyBuild() error = %v", err)
+	}
+	if session.calls != 1 {
+		t.Fatalf("session calls = %d, want 1", session.calls)
+	}
+	for _, msg := range loop.Messages {
+		if msg.Role == "system" {
+			t.Fatalf("unexpected system alert injected on successful build: %q", msg.Content)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up from the issue 203 dogfood pass. Router and smartrouter MiniMax smoke runs exposed that router requests were forwarding the active MiniMax model to other provider tiers, which made OpenAI reject the request with Unknown Model. The command surface pass also exposed a false compile alert after successful read-only sh commands.

This PR:
- sends the active run model only to the matching active provider inside RouterSolver; other tiers fall back to their configured provider defaults
- preserves the displayed solver name so explicit router runs report harness router while auto smartrouter still reports smartrouter
- makes auto build verification skip read-only sh invocations while still verifying known mutating shell commands and other mutating tools
- routes verifyBuild through the active executor session and host workspace mapping

## Evidence

Broken before:
- router run 20260524T155318-073fc76f: OpenAI Unknown Model
- smartrouter run 20260524T155318-05b6a416: OpenAI Unknown Model

Fixed live runs:
- router run 20260524T160011-d9969edb succeeded and reported harness router
- smartrouter run 20260524T160011-7c2674f1 succeeded and reported harness smartrouter
- sh cap run 20260524T160242-6180378e confirmed capped/truncated large shell output
- false alert reproduced in 20260524T163100-1ead18d5
- false alert fixed in 20260524T163310-73181a48; trace search found no SYSTEM ALERT/no active sandbox session/compilation error

## Tests

- make lint
- make test
- make build
- env GOCACHE=/tmp/v100-gocache go test ./internal/core ./cmd/v100 -run 'TestVerifyBuildUsesActiveSession|TestShouldVerifyBuildAfterShell|TestRouterSolver|TestBuildSolver' -count=1
- env GOCACHE=/tmp/v100-gocache go vet ./cmd/... ./internal/...