### PR TITLE
feat: discover behavior definitions from config dirs

### DIFF
--- a/cmd/v100/cmd_wake.go
+++ b/cmd/v100/cmd_wake.go
@@ -1645,7 +1645,7 @@ func buildStepPrompt(promptBaseDir string, task *config.WakeTask, stepIndex int,
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "Task: %s — Step %d of %d: %s\n", task.Name, stepIndex+1, len(task.Steps), step.Name)
-	stepText, err := step.ResolvePrompt(promptBaseDir)
+	stepText, err := step.ResolvePrompt(task.PromptBaseDir(promptBaseDir))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/v100/cmd_wake_test.go
+++ b/cmd/v100/cmd_wake_test.go
@@ -588,6 +588,59 @@ func TestBuildStepPromptUsesConfigRelativePromptPath(t *testing.T) {
 	}
 }
 
+func TestBuildStepPromptUsesTaskSourceDir(t *testing.T) {
+	configDir := t.TempDir()
+	taskDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(taskDir, "step.md"), []byte("from task dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := &config.WakeTask{
+		SourceDir: taskDir,
+		Name:      "daily",
+		Steps:     []config.WakeTaskStep{{Name: "read"}},
+	}
+	step := config.WakeTaskStep{Name: "read", PromptPath: "step.md"}
+
+	got, err := buildStepPrompt(configDir, task, 0, step, "")
+	if err != nil {
+		t.Fatalf("buildStepPrompt() error = %v", err)
+	}
+	if !strings.Contains(got, "from task dir") {
+		t.Fatalf("prompt missing task-dir file content: %q", got)
+	}
+}
+
+func TestLoadConfigDiscoversWakeTaskDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[defaults]
+provider = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	taskDir := filepath.Join(dir, "tasks", "directory-task")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "step.md"), []byte("directory task prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "task.toml"), []byte(`[[steps]]
+name = "read"
+prompt_path = "step.md"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if !strings.Contains(wakeTaskNames(cfg), "directory-task") {
+		t.Fatalf("wakeTaskNames() missing directory-task: %s", wakeTaskNames(cfg))
+	}
+}
+
 func TestBuildStepPromptFailsOnMissingPromptPath(t *testing.T) {
 	task := &config.WakeTask{Name: "daily", Steps: []config.WakeTaskStep{{Name: "read"}}}
 	step := config.WakeTaskStep{

--- a/cmd/v100/helpers.go
+++ b/cmd/v100/helpers.go
@@ -27,10 +27,28 @@ func loadConfig(cfgPath string) (*config.Config, error) {
 	if cfgPath == "" {
 		cfgPath = config.XDGConfigPath()
 	}
+	cfgPath = expandHomePath(cfgPath)
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
-		return config.DefaultConfig(), nil
+		cfg := config.DefaultConfig()
+		sourcePath := cfgPath
+		if abs, err := filepath.Abs(sourcePath); err == nil {
+			sourcePath = abs
+		}
+		cfg.SourceDir = filepath.Dir(sourcePath)
+		if err := config.LoadBehaviorDirectories(cfg); err != nil {
+			return nil, err
+		}
+		return cfg, nil
 	}
 	return config.Load(cfgPath)
+}
+
+func expandHomePath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, path[2:])
+	}
+	return path
 }
 
 func configuredAgentNames(cfg *config.Config) []string {

--- a/cmd/v100/helpers_agents_test.go
+++ b/cmd/v100/helpers_agents_test.go
@@ -56,6 +56,41 @@ func TestAgentsCmdListsDefaultRoles(t *testing.T) {
 	}
 }
 
+func TestAgentsCmdListsDirectoryRoles(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[defaults]
+provider = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsDir := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "critic.toml"), []byte(`system_prompt = "critic"
+tools = ["fs_read"]
+model = "glm"
+budget_steps = 3
+budget_tokens = 123
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(func() error {
+		cmd := agentsCmd(&cfgPath)
+		return cmd.RunE(cmd, nil)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"critic", "model=glm", "tokens=123", "fs_read"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("agents output missing %q in:\n%s", want, out)
+		}
+	}
+}
+
 func TestResolveAgentSystemPromptUsesConfigSourceDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "agent.md"), []byte("from file"), 0o644); err != nil {
@@ -74,6 +109,27 @@ func TestResolveAgentSystemPromptUsesConfigSourceDir(t *testing.T) {
 	}
 	if got != "from file" {
 		t.Fatalf("resolveAgentSystemPrompt() = %q, want file prompt", got)
+	}
+}
+
+func TestResolveAgentSystemPromptUsesAgentSourceDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "agent.md"), []byte("from agent dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.SourceDir = t.TempDir()
+	role := config.AgentConfig{
+		SourceDir:        dir,
+		SystemPromptPath: "agent.md",
+	}
+
+	got, err := resolveAgentSystemPrompt(cfg, role)
+	if err != nil {
+		t.Fatalf("resolveAgentSystemPrompt() error = %v", err)
+	}
+	if got != "from agent dir" {
+		t.Fatalf("resolveAgentSystemPrompt() = %q, want agent-dir prompt", got)
 	}
 }
 

--- a/cmd/v100/helpers_policy_test.go
+++ b/cmd/v100/helpers_policy_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/tripledoublev/v100/internal/config"
@@ -48,6 +50,35 @@ func TestLoadPolicyPreservesStaleToolElideDisabled(t *testing.T) {
 	p := loadPolicy(cfg, "default")
 	if p.StaleToolElideSteps != -1 {
 		t.Fatalf("StaleToolElideSteps = %d, want -1 (disabled)", p.StaleToolElideSteps)
+	}
+}
+
+func TestLoadPolicyUsesDiscoveredPolicyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[defaults]
+provider = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policiesDir := filepath.Join(dir, "policies")
+	if err := os.MkdirAll(policiesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policiesDir, "review.md"), []byte("review policy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	p := loadPolicy(cfg, "review")
+	if p.Name != "review" {
+		t.Fatalf("policy name = %q, want review", p.Name)
+	}
+	if p.SystemPrompt != "review policy" {
+		t.Fatalf("policy prompt = %q, want discovered markdown policy", p.SystemPrompt)
 	}
 }
 

--- a/internal/config/behavior_dirs.go
+++ b/internal/config/behavior_dirs.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	taskManifestName   = "task.toml"
+	policyManifestName = "policy.toml"
+)
+
+// LoadBehaviorDirectories merges standalone behavioral definitions from
+// agents/, tasks/, and policies/ directories beside the active config file.
+func LoadBehaviorDirectories(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	baseDir := cfg.PromptBaseDir()
+	if err := loadAgentDefinitions(cfg, filepath.Join(baseDir, "agents")); err != nil {
+		return err
+	}
+	if err := loadTaskDefinitions(cfg, filepath.Join(baseDir, "tasks")); err != nil {
+		return err
+	}
+	if err := loadPolicyDefinitions(cfg, filepath.Join(baseDir, "policies")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadAgentDefinitions(cfg *Config, dir string) error {
+	agents, err := LoadAgentsDirectory(dir)
+	if err != nil {
+		return err
+	}
+	if len(agents) == 0 {
+		return nil
+	}
+	if cfg.Agents == nil {
+		cfg.Agents = map[string]AgentConfig{}
+	}
+	for _, name := range sortedMapKeys(agents) {
+		cfg.Agents[name] = agents[name]
+	}
+	return nil
+}
+
+func loadTaskDefinitions(cfg *Config, dir string) error {
+	tasks, err := LoadTasksDirectory(dir)
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	cfg.Wake.Tasks = mergeWakeTasks(cfg.Wake.Tasks, tasks)
+	return nil
+}
+
+func loadPolicyDefinitions(cfg *Config, dir string) error {
+	policies, err := LoadPoliciesDirectory(dir)
+	if err != nil {
+		return err
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	if cfg.Policies == nil {
+		cfg.Policies = map[string]PolicyConfig{}
+	}
+	for _, name := range sortedMapKeys(policies) {
+		cfg.Policies[name] = policies[name]
+	}
+	return nil
+}
+
+func mergeWakeTasks(existing []WakeTask, loaded map[string]WakeTask) []WakeTask {
+	if len(loaded) == 0 {
+		return existing
+	}
+	out := append([]WakeTask(nil), existing...)
+	index := map[string]int{}
+	for i, task := range out {
+		name := strings.TrimSpace(task.Name)
+		if name != "" {
+			index[name] = i
+		}
+	}
+	for _, name := range sortedMapKeys(loaded) {
+		task := loaded[name]
+		if i, ok := index[name]; ok {
+			out[i] = task
+			continue
+		}
+		index[name] = len(out)
+		out = append(out, task)
+	}
+	return out
+}
+
+// LoadTaskFile loads a standalone wake task from a TOML file.
+func LoadTaskFile(path string) (WakeTask, error) {
+	defaultName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	return loadTaskFile(path, defaultName)
+}
+
+func loadTaskFile(path, defaultName string) (WakeTask, error) {
+	var task WakeTask
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return task, fmt.Errorf("read task file %q: %w", path, err)
+	}
+	if _, err := toml.Decode(string(data), &task); err != nil {
+		return task, fmt.Errorf("parse task file %q: %w", path, err)
+	}
+	task.SourceDir = configSourceDir(path)
+	if strings.TrimSpace(task.Name) == "" {
+		task.Name = defaultName
+	}
+	return task, nil
+}
+
+// LoadTasksDirectory loads standalone wake tasks from tasks/*.toml and
+// tasks/<name>/task.toml. Directory task manifests resolve prompt_path entries
+// relative to the task directory.
+func LoadTasksDirectory(dir string) (map[string]WakeTask, error) {
+	tasks := map[string]WakeTask{}
+	entries, err := sortedDirEntries(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return tasks, nil
+		}
+		return nil, fmt.Errorf("read tasks directory %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		switch {
+		case entry.IsDir():
+			manifestPath := filepath.Join(path, taskManifestName)
+			if _, err := os.Stat(manifestPath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, fmt.Errorf("stat task manifest %q: %w", manifestPath, err)
+			}
+			task, err := loadTaskFile(manifestPath, name)
+			if err != nil {
+				return nil, err
+			}
+			if err := addTask(tasks, task); err != nil {
+				return nil, err
+			}
+		case strings.HasSuffix(name, ".toml") && name != taskManifestName:
+			task, err := LoadTaskFile(path)
+			if err != nil {
+				return nil, err
+			}
+			if err := addTask(tasks, task); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return tasks, nil
+}
+
+func addTask(tasks map[string]WakeTask, task WakeTask) error {
+	name := strings.TrimSpace(task.Name)
+	if name == "" {
+		return fmt.Errorf("task definition in %q has no name", task.SourceDir)
+	}
+	if _, exists := tasks[name]; exists {
+		return fmt.Errorf("duplicate task definition %q", name)
+	}
+	tasks[name] = task
+	return nil
+}
+
+// LoadPolicyFile loads a standalone policy definition from a TOML file.
+func LoadPolicyFile(path string) (PolicyConfig, error) {
+	var pc PolicyConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pc, fmt.Errorf("read policy file %q: %w", path, err)
+	}
+	if _, err := toml.Decode(string(data), &pc); err != nil {
+		return pc, fmt.Errorf("parse policy file %q: %w", path, err)
+	}
+	pc.SourceDir = configSourceDir(path)
+	return pc, nil
+}
+
+// LoadPoliciesDirectory loads policies from policies/*.toml, policies/*.md,
+// policies/*.txt, and policies/<name>/policy.toml.
+func LoadPoliciesDirectory(dir string) (map[string]PolicyConfig, error) {
+	policies := map[string]PolicyConfig{}
+	entries, err := sortedDirEntries(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return policies, nil
+		}
+		return nil, fmt.Errorf("read policies directory %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		switch {
+		case entry.IsDir():
+			manifestPath := filepath.Join(path, policyManifestName)
+			if _, err := os.Stat(manifestPath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, fmt.Errorf("stat policy manifest %q: %w", manifestPath, err)
+			}
+			pc, err := LoadPolicyFile(manifestPath)
+			if err != nil {
+				return nil, err
+			}
+			if err := addPolicy(policies, name, pc); err != nil {
+				return nil, err
+			}
+		case strings.HasSuffix(name, ".toml") && name != policyManifestName:
+			pc, err := LoadPolicyFile(path)
+			if err != nil {
+				return nil, err
+			}
+			key := strings.TrimSuffix(name, ".toml")
+			if err := addPolicy(policies, key, pc); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".md") || strings.HasSuffix(name, ".txt") {
+			key := strings.TrimSuffix(name, filepath.Ext(name))
+			if _, exists := policies[key]; exists {
+				continue
+			}
+			pc := PolicyConfig{SourceDir: dir, SystemPromptPath: name}
+			if err := addPolicy(policies, key, pc); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return policies, nil
+}
+
+func addPolicy(policies map[string]PolicyConfig, name string, pc PolicyConfig) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("policy definition has no name")
+	}
+	if _, exists := policies[name]; exists {
+		return fmt.Errorf("duplicate policy definition %q", name)
+	}
+	policies[name] = pc
+	return nil
+}
+
+func sortedDirEntries(dir string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+	return entries, nil
+}
+
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,9 @@ type WakeConfig struct {
 
 // WakeTask defines a named multi-step task for synthesis wake mode.
 type WakeTask struct {
+	// SourceDir is the directory containing the standalone task definition.
+	// It is runtime metadata, not a TOML setting.
+	SourceDir   string         `toml:"-"`
 	Name        string         `toml:"name"`
 	Description string         `toml:"description"`
 	Schedule    string         `toml:"schedule"` // e.g. "24h"
@@ -130,6 +133,9 @@ type ToolsConfig struct {
 
 // PolicyConfig holds specific named policies.
 type PolicyConfig struct {
+	// SourceDir is the directory containing the standalone policy definition.
+	// It is runtime metadata, not a TOML setting.
+	SourceDir           string `toml:"-"`
 	SystemPromptPath    string `toml:"system_prompt_path"`
 	SystemPrompt        string `toml:"system_prompt"` // inline prompt override
 	MaxToolCallsPerStep int    `toml:"max_tool_calls_per_step"`
@@ -139,6 +145,9 @@ type PolicyConfig struct {
 
 // AgentConfig holds sub-agent persona definitions.
 type AgentConfig struct {
+	// SourceDir is the directory containing the standalone agent definition.
+	// It is runtime metadata, not a TOML setting.
+	SourceDir        string   `toml:"-"`
 	SystemPrompt     string   `toml:"system_prompt"`
 	SystemPromptPath string   `toml:"system_prompt_path"` // optional path to .md/.txt file containing the system prompt
 	Tools            []string `toml:"tools"`
@@ -327,6 +336,11 @@ func DefaultConfig() *Config {
 // DefaultTOML returns the default config as a TOML string.
 func DefaultTOML() string {
 	return `# v100 configuration
+#
+# Behavioral definitions can live beside this file:
+# - agents/*.toml
+# - tasks/*.toml or tasks/<name>/task.toml
+# - policies/*.md, policies/*.txt, policies/*.toml, or policies/<name>/policy.toml
 
 [providers.smartrouter]
 type = "smartrouter"
@@ -520,6 +534,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Embedding.Model == "" {
 		cfg.Embedding.Model = DefaultConfig().Embedding.Model
+	}
+	if err := LoadBehaviorDirectories(&cfg); err != nil {
+		return nil, err
 	}
 	return &cfg, nil
 }

--- a/internal/config/prompt_resolver.go
+++ b/internal/config/prompt_resolver.go
@@ -9,9 +9,9 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// resolvePromptPath reads a prompt from the given path, applying ~ expansion
-// and resolving relative paths against baseDir.
-func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
+// ResolvePromptFilePath applies ~ expansion and resolves relative prompt paths
+// against baseDir.
+func ResolvePromptFilePath(rawPath, baseDir string) string {
 	path := expandHome(rawPath)
 	if !filepath.IsAbs(path) {
 		if strings.TrimSpace(baseDir) == "" {
@@ -19,11 +19,25 @@ func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
 		}
 		path = filepath.Join(baseDir, path)
 	}
+	return path
+}
+
+// resolvePromptPath reads a prompt from the given path, applying ~ expansion
+// and resolving relative paths against baseDir.
+func resolvePromptPath(rawPath, baseDir, field string) (string, error) {
+	path := ResolvePromptFilePath(rawPath, baseDir)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("read %s %q: %w", field, path, err)
 	}
 	return string(data), nil
+}
+
+func sourceBaseDir(sourceDir, fallbackBaseDir string) string {
+	if strings.TrimSpace(sourceDir) != "" {
+		return sourceDir
+	}
+	return fallbackBaseDir
 }
 
 // PromptBaseDir returns the directory relative prompt paths should resolve
@@ -54,7 +68,13 @@ func (a AgentConfig) ResolvePrompt(baseDir string) (string, error) {
 	if strings.TrimSpace(a.SystemPromptPath) == "" {
 		return a.SystemPrompt, nil
 	}
-	return resolvePromptPath(a.SystemPromptPath, baseDir, "system_prompt_path")
+	return resolvePromptPath(a.SystemPromptPath, sourceBaseDir(a.SourceDir, baseDir), "system_prompt_path")
+}
+
+// PromptBaseDir returns the base directory for resolving this task's step
+// prompt paths.
+func (t WakeTask) PromptBaseDir(baseDir string) string {
+	return sourceBaseDir(t.SourceDir, baseDir)
 }
 
 // ResolvePrompt returns the resolved prompt for a wake task step.
@@ -66,6 +86,14 @@ func (s WakeTaskStep) ResolvePrompt(baseDir string) (string, error) {
 		return s.Prompt, nil
 	}
 	return resolvePromptPath(s.PromptPath, baseDir, "prompt_path")
+}
+
+// ResolvePrompt returns the resolved system prompt for a policy config.
+func (p PolicyConfig) ResolvePrompt(baseDir string) (string, error) {
+	if strings.TrimSpace(p.SystemPromptPath) == "" {
+		return p.SystemPrompt, nil
+	}
+	return resolvePromptPath(p.SystemPromptPath, sourceBaseDir(p.SourceDir, baseDir), "system_prompt_path")
 }
 
 // XDGConfigDir returns the directory containing the user's v100 config file.
@@ -86,6 +114,7 @@ func LoadAgentFile(path string) (AgentConfig, error) {
 	if _, err := toml.Decode(string(data), &agent); err != nil {
 		return agent, fmt.Errorf("parse agent file %q: %w", path, err)
 	}
+	agent.SourceDir = configSourceDir(path)
 	return agent, nil
 }
 

--- a/internal/config/prompt_resolver_test.go
+++ b/internal/config/prompt_resolver_test.go
@@ -146,7 +146,7 @@ tools = ["fs_read"]
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	prompt, err := agent.ResolvePrompt(dir)
+	prompt, err := agent.ResolvePrompt("")
 	if err != nil {
 		t.Fatalf("resolve error: %v", err)
 	}
@@ -193,6 +193,214 @@ func TestLoadAgentsDirectory_MissingDir(t *testing.T) {
 	if len(agents) != 0 {
 		t.Errorf("expected empty map, got %d agents", len(agents))
 	}
+}
+
+func TestLoadTasksDirectorySupportsFilesAndTaskDirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "single.toml"), []byte(`description = "single file"
+[[steps]]
+name = "read"
+prompt = "inline"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	taskDir := filepath.Join(dir, "complex")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "draft.md"), []byte("prompt from task dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "task.toml"), []byte(`description = "directory task"
+[[steps]]
+name = "draft"
+prompt_path = "draft.md"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks, err := LoadTasksDirectory(dir)
+	if err != nil {
+		t.Fatalf("LoadTasksDirectory() error = %v", err)
+	}
+	if tasks["single"].Name != "single" {
+		t.Fatalf("single task name = %q, want single", tasks["single"].Name)
+	}
+	complex := tasks["complex"]
+	if complex.Name != "complex" {
+		t.Fatalf("complex task name = %q, want complex", complex.Name)
+	}
+	got, err := complex.Steps[0].ResolvePrompt(complex.PromptBaseDir(""))
+	if err != nil {
+		t.Fatalf("ResolvePrompt() error = %v", err)
+	}
+	if got != "prompt from task dir" {
+		t.Fatalf("directory task prompt = %q", got)
+	}
+}
+
+func TestLoadPoliciesDirectorySupportsMarkdownTomlAndDirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "direct.md"), []byte("direct prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review.toml"), []byte(`system_prompt = "review prompt"
+max_tool_calls_per_step = 12
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policyDir := filepath.Join(dir, "complex")
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "prompt.md"), []byte("complex prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.toml"), []byte(`system_prompt_path = "prompt.md"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPoliciesDirectory(dir)
+	if err != nil {
+		t.Fatalf("LoadPoliciesDirectory() error = %v", err)
+	}
+	directPrompt, err := policies["direct"].ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("direct ResolvePrompt() error = %v", err)
+	}
+	if directPrompt != "direct prompt" {
+		t.Fatalf("direct prompt = %q", directPrompt)
+	}
+	if policies["review"].MaxToolCallsPerStep != 12 {
+		t.Fatalf("review max calls = %d, want 12", policies["review"].MaxToolCallsPerStep)
+	}
+	complexPrompt, err := policies["complex"].ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("complex ResolvePrompt() error = %v", err)
+	}
+	if complexPrompt != "complex prompt" {
+		t.Fatalf("complex prompt = %q", complexPrompt)
+	}
+}
+
+func TestLoadPoliciesDirectoryLetsTomlOverrideSameNameMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "default.md"), []byte("default markdown"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "default.toml"), []byte(`system_prompt_path = "default.md"
+max_tool_calls_per_step = 77
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPoliciesDirectory(dir)
+	if err != nil {
+		t.Fatalf("LoadPoliciesDirectory() error = %v", err)
+	}
+	if policies["default"].MaxToolCallsPerStep != 77 {
+		t.Fatalf("MaxToolCallsPerStep = %d, want 77", policies["default"].MaxToolCallsPerStep)
+	}
+	got, err := policies["default"].ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("ResolvePrompt() error = %v", err)
+	}
+	if got != "default markdown" {
+		t.Fatalf("prompt = %q, want default markdown", got)
+	}
+}
+
+func TestLoadMergesBehaviorDirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(`[defaults]
+provider = "codex"
+
+[agents.inline]
+system_prompt = "inline"
+
+[[wake.tasks]]
+name = "inline-task"
+[[wake.tasks.steps]]
+name = "inline"
+prompt = "inline task"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsDir := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "file-agent.md"), []byte("agent prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "file-agent.toml"), []byte(`system_prompt_path = "file-agent.md"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tasksDir := filepath.Join(dir, "tasks", "file-task")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tasksDir, "step.md"), []byte("task prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tasksDir, "task.toml"), []byte(`[[steps]]
+name = "step"
+prompt_path = "step.md"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policiesDir := filepath.Join(dir, "policies")
+	if err := os.MkdirAll(policiesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(policiesDir, "file-policy.md"), []byte("policy prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	agentPrompt, err := cfg.Agents["file-agent"].ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("agent ResolvePrompt() error = %v", err)
+	}
+	if agentPrompt != "agent prompt" {
+		t.Fatalf("agent prompt = %q", agentPrompt)
+	}
+	if cfg.Agents["inline"].SystemPrompt != "inline" {
+		t.Fatal("inline agent should remain available")
+	}
+	fileTask := findTaskForTest(cfg.Wake.Tasks, "file-task")
+	if fileTask == nil {
+		t.Fatal("file-task not loaded")
+	}
+	taskPrompt, err := fileTask.Steps[0].ResolvePrompt(fileTask.PromptBaseDir(cfg.PromptBaseDir()))
+	if err != nil {
+		t.Fatalf("task ResolvePrompt() error = %v", err)
+	}
+	if taskPrompt != "task prompt" {
+		t.Fatalf("task prompt = %q", taskPrompt)
+	}
+	if findTaskForTest(cfg.Wake.Tasks, "inline-task") == nil {
+		t.Fatal("inline task should remain available")
+	}
+	policyPrompt, err := cfg.Policies["file-policy"].ResolvePrompt("")
+	if err != nil {
+		t.Fatalf("policy ResolvePrompt() error = %v", err)
+	}
+	if policyPrompt != "policy prompt" {
+		t.Fatalf("policy prompt = %q", policyPrompt)
+	}
+}
+
+func findTaskForTest(tasks []WakeTask, name string) *WakeTask {
+	for i := range tasks {
+		if tasks[i].Name == name {
+			return &tasks[i]
+		}
+	}
+	return nil
 }
 
 func TestAgentConfig_ResolvePrompt_TildeExpansion(t *testing.T) {

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -25,7 +25,7 @@ func Load(name string, cfg config.PolicyConfig) (*Policy, error) {
 	}
 
 	if cfg.SystemPromptPath != "" {
-		promptPath := expandHome(cfg.SystemPromptPath)
+		promptPath := config.ResolvePromptFilePath(cfg.SystemPromptPath, cfg.SourceDir)
 		data, err := os.ReadFile(promptPath)
 		if err == nil {
 			prompt := string(data)
@@ -40,6 +40,10 @@ func Load(name string, cfg config.PolicyConfig) (*Policy, error) {
 			return nil, fmt.Errorf("policy %s: read prompt %s: %w", name, promptPath, err)
 		}
 		// File doesn't exist — use default
+	}
+	if strings.TrimSpace(cfg.SystemPrompt) != "" {
+		p.SystemPrompt = cfg.SystemPrompt
+		return p, nil
 	}
 
 	p.SystemPrompt = DefaultSystemPrompt
@@ -72,14 +76,6 @@ func WriteDefaultPrompt() error {
 	}
 	path := filepath.Join(dir, "default.md")
 	return os.WriteFile(path, []byte(DefaultSystemPrompt), 0o644)
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~/") {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, path[2:])
-	}
-	return path
 }
 
 func migrateLegacyDefaultPrompt(prompt string) (string, bool) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -68,6 +68,40 @@ func TestLoadFallbackToDefault(t *testing.T) {
 	}
 }
 
+func TestLoadInlineSystemPrompt(t *testing.T) {
+	p, err := Load("inline", config.PolicyConfig{
+		SystemPrompt:        "inline policy",
+		MaxToolCallsPerStep: 9,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.SystemPrompt != "inline policy" {
+		t.Fatalf("SystemPrompt = %q, want inline policy", p.SystemPrompt)
+	}
+	if p.MaxToolCallsPerStep != 9 {
+		t.Fatalf("MaxToolCallsPerStep = %d, want 9", p.MaxToolCallsPerStep)
+	}
+}
+
+func TestLoadRelativePromptFromPolicySourceDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "policy.md"), []byte("source-dir policy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := Load("source-dir", config.PolicyConfig{
+		SourceDir:        dir,
+		SystemPromptPath: "policy.md",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.SystemPrompt != "source-dir policy" {
+		t.Fatalf("SystemPrompt = %q, want source-dir policy", p.SystemPrompt)
+	}
+}
+
 func TestLoadDefaultMaxToolCalls(t *testing.T) {
 	p, err := Load("zero", config.PolicyConfig{
 		MaxToolCallsPerStep: 0,


### PR DESCRIPTION
## Summary

Closes #214.

This implements first-class behavioral definition directories next to the active config file:
- agents/*.toml
- tasks/*.toml and tasks/<name>/task.toml
- policies/*.md, policies/*.txt, policies/*.toml, and policies/<name>/policy.toml

The config loader now merges those definitions after inline config/defaults so existing inline [agents] and [[wake.tasks]] remain compatible while directory definitions become directly usable. Standalone definitions keep SourceDir metadata so relative prompt paths resolve beside the file or task/policy manifest.

Command/runtime wiring:
- v100 agents now lists discovered agent files through normal loadConfig
- agent dispatch can use discovered agents through cfg.Agents
- v100 wake task <name> now sees discovered task definitions through cfg.Wake.Tasks
- wake task step prompt_path resolves relative to a task directory manifest
- loadPolicy can use discovered policy markdown/TOML definitions and inline system_prompt

Also fixed loadConfig to expand ~/ before deciding whether a config path exists, so explicit home-relative config paths work with directory discovery.

## Verification

- make lint
- make test
- make build
- env GOCACHE=/tmp/v100-gocache go vet ./cmd/... ./internal/...
- go test ./internal/config ./internal/policy ./cmd/v100 -count=1
- Binary smoke with temp config:
  - ./v100 --config <tmp>/config.toml agents listed directory-defined critic role
  - ./v100 --config <tmp>/config.toml wake task missing-task reported available tasks: directory-task

## Notes

Existing untracked local files .sprite and news.html were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for organizing agents, wake tasks, and policies in dedicated directories (`agents/`, `tasks/`, `policies/`) alongside configuration files for improved modularity.
  * Enabled discovery and loading of behaviors from directory structures with automatic configuration merging.
  * Added support for inline system prompts in policies for simplified configuration.

* **Tests**
  * Comprehensive test coverage for directory-based behavior discovery and configuration merging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->