### PR TITLE
fix: guard external tools with rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ v100 is designed for long-running, unattended execution:
 ### 3. Tooling & Safety
 Tools are a first-class part of the runtime. The model interacts with the world through explicitly registered, schema-bound tools (40+ currently available):
 - **Safety boundaries**: Tools are marked `Safe` or `Dangerous`. Dangerous tools can require explicit operator confirmation, trigger mandatory "Reflection" turns (`Policy.ReflectOnDangerous`) to assess confidence, or be blocked entirely.
+- **External API guardrails**: ATProto and news tools use per-endpoint token-bucket rate limits and circuit breakers. `atproto_index`, `atproto_graph_explorer`, and `news_fetch` cap paginated requests at 100 items per call; repeated HTTP 429 responses emit structured alerts and open exponential backoff. `atproto_post` returns a dry-run preview unless `confirm=true` is supplied.
 - **Sandboxing**: Runs can be executed inside isolated Docker containers with strict **Network Tiers** to prevent unauthorized data exfiltration.
 - **Semantic analysis**: Includes tools like `sem_diff`, `sem_impact`, and `sem_blame` that understand code entities such as functions and classes.
 

--- a/internal/tools/atproto.go
+++ b/internal/tools/atproto.go
@@ -250,13 +250,40 @@ func (t *atprotoNotificationsTool) Exec(_ context.Context, _ ToolCallContext, ar
 type atprotoPostTool struct{ cfg *config.Config }
 type atprotoCreateRecordTool struct{ cfg *config.Config }
 
+type atprotoPostArgs struct {
+	Text       string `json:"text"`
+	ReplyToURI string `json:"reply_to_uri"`
+	ReplyToCID string `json:"reply_to_cid"`
+	RootURI    string `json:"root_uri"`
+	RootCID    string `json:"root_cid"`
+	QuoteURI   string `json:"quote_uri"`
+	QuoteCID   string `json:"quote_cid"`
+	RepostURI  string `json:"repost_uri"`
+	RepostCID  string `json:"repost_cid"`
+	Images     []struct {
+		CID  string `json:"cid"`
+		Mime string `json:"mime"`
+		Size int64  `json:"size"`
+		Alt  string `json:"alt"`
+	} `json:"images"`
+	Account string `json:"account"`
+	DryRun  bool   `json:"dry_run"`
+	Confirm bool   `json:"confirm"`
+}
+
+type atprotoPostPlan struct {
+	Action     string
+	Collection string
+	Record     map[string]any
+}
+
 // ATProtoPost returns the atproto_post tool.
 func ATProtoPost(cfg *config.Config) Tool         { return &atprotoPostTool{cfg: cfg} }
 func ATProtoCreateRecord(cfg *config.Config) Tool { return &atprotoCreateRecordTool{cfg: cfg} }
 
 func (t *atprotoPostTool) Name() string { return "atproto_post" }
 func (t *atprotoPostTool) Description() string {
-	return "Publish to Bluesky. Supports plain posts, replies (reply_to_uri + reply_to_cid), quote posts (quote_uri + quote_cid), reposts (repost_uri + repost_cid; text ignored), and image posts via the images array (each item: cid, mime, size, optional alt - use atproto_upload_blob first to obtain these). Quote+images are combined as a recordWithMedia embed."
+	return "Publish to Bluesky with a dry-run preview and confirm=true requirement for real posts. Supports plain posts, replies (reply_to_uri + reply_to_cid), quote posts (quote_uri + quote_cid), reposts (repost_uri + repost_cid; text ignored), and image posts via the images array (each item: cid, mime, size, optional alt - use atproto_upload_blob first). Quote+images are combined as a recordWithMedia embed. ATProto requests are protected by per-endpoint rate limits and a circuit breaker."
 }
 func (t *atprotoPostTool) DangerLevel() DangerLevel { return Dangerous }
 func (t *atprotoPostTool) Effects() ToolEffects {
@@ -376,7 +403,9 @@ func (t *atprotoPostTool) InputSchema() json.RawMessage {
 			"repost_uri":   {"type": "string",  "description": "AT URI of the post to repost (text not required)."},
 			"repost_cid":   {"type": "string",  "description": "CID of the post to repost (required with repost_uri)."},
 			"images":       {"type": "array",   "description": "Optional image attachments. Each item: {cid, mime, size, alt?}. Obtain cid/mime/size by calling atproto_upload_blob first.", "items": {"type": "object", "properties": {"cid": {"type": "string"}, "mime": {"type": "string"}, "size": {"type": "integer"}, "alt": {"type": "string"}}, "required": ["cid", "mime", "size"]}},
-			"account":      {"type": "string",  "description": "Which account to post from: \"main\" (default, charlebois.info) or \"alt\" (xx-c.art)."}
+			"account":      {"type": "string",  "description": "Which account to post from: \"main\" (default, charlebois.info) or \"alt\" (xx-c.art)."},
+			"dry_run":      {"type": "boolean", "description": "When true, return the exact post/repost preview without publishing."},
+			"confirm":      {"type": "boolean", "description": "Must be true to publish. When omitted or false, the tool returns a dry-run preview instead of posting."}
 		}
 	}`)
 }
@@ -393,24 +422,7 @@ func (t *atprotoPostTool) OutputSchema() json.RawMessage {
 }
 
 func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.RawMessage) (ToolResult, error) {
-	var in struct {
-		Text       string `json:"text"`
-		ReplyToURI string `json:"reply_to_uri"`
-		ReplyToCID string `json:"reply_to_cid"`
-		RootURI    string `json:"root_uri"`
-		RootCID    string `json:"root_cid"`
-		QuoteURI   string `json:"quote_uri"`
-		QuoteCID   string `json:"quote_cid"`
-		RepostURI  string `json:"repost_uri"`
-		RepostCID  string `json:"repost_cid"`
-		Images     []struct {
-			CID  string `json:"cid"`
-			Mime string `json:"mime"`
-			Size int64  `json:"size"`
-			Alt  string `json:"alt"`
-		} `json:"images"`
-		Account string `json:"account"`
-	}
+	var in atprotoPostArgs
 	if err := json.Unmarshal(args, &in); err != nil {
 		return ToolResult{OK: false, Output: "invalid args: " + err.Error()}, nil
 	}
@@ -419,45 +431,71 @@ func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 	if err != nil {
 		return ToolResult{OK: false, Output: err.Error()}, nil
 	}
+	accountName := normalizedATProtoAccountName(in.Account)
+
+	plan, err := buildATProtoPostPlan(in, time.Now().UTC())
+	if err != nil {
+		return ToolResult{OK: false, Output: err.Error()}, nil
+	}
+	if in.DryRun || !in.Confirm {
+		return atprotoPostPreviewResult(in, accountName, plan, !in.Confirm && !in.DryRun), nil
+	}
+
 	cli := newATProtoClient(accountCfg)
 	if err := cli.login(); err != nil {
 		return ToolResult{OK: false, Output: err.Error()}, nil
 	}
 
-	// Repost path — separate lexicon.
-	if in.RepostURI != "" && in.RepostCID != "" {
-		payload := map[string]any{
-			"repo":       cli.session.DID,
-			"collection": "app.bsky.feed.repost",
-			"record": map[string]any{
+	payload := map[string]any{
+		"repo":       cli.session.DID,
+		"collection": plan.Collection,
+		"record":     plan.Record,
+	}
+	data, err := cli.xrpcPost("com.atproto.repo.createRecord", payload)
+	if err != nil {
+		return ToolResult{OK: false, Output: err.Error()}, nil
+	}
+
+	var out struct {
+		URI string `json:"uri"`
+		CID string `json:"cid"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
+	}
+	return CapToolResult(ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}), nil
+}
+
+func buildATProtoPostPlan(in atprotoPostArgs, now time.Time) (atprotoPostPlan, error) {
+	if in.RepostURI != "" || in.RepostCID != "" {
+		if in.RepostURI == "" || in.RepostCID == "" {
+			return atprotoPostPlan{}, fmt.Errorf("repost_uri and repost_cid are required together")
+		}
+		return atprotoPostPlan{
+			Action:     "repost",
+			Collection: "app.bsky.feed.repost",
+			Record: map[string]any{
 				"$type":     "app.bsky.feed.repost",
 				"subject":   map[string]string{"uri": in.RepostURI, "cid": in.RepostCID},
-				"createdAt": time.Now().UTC().Format(time.RFC3339),
+				"createdAt": now.Format(time.RFC3339),
 			},
-		}
-		data, err := cli.xrpcPost("com.atproto.repo.createRecord", payload)
-		if err != nil {
-			return ToolResult{OK: false, Output: err.Error()}, nil
-		}
-		var out struct {
-			URI string `json:"uri"`
-			CID string `json:"cid"`
-		}
-		if err := json.Unmarshal(data, &out); err != nil {
-			return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
-		}
-		return CapToolResult(ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}), nil
+		}, nil
 	}
 
 	if in.Text == "" && len(in.Images) == 0 {
-		return ToolResult{OK: false, Output: "text is required"}, nil
+		return atprotoPostPlan{}, fmt.Errorf("text is required")
+	}
+	if (in.ReplyToURI == "") != (in.ReplyToCID == "") {
+		return atprotoPostPlan{}, fmt.Errorf("reply_to_uri and reply_to_cid are required together")
+	}
+	if (in.QuoteURI == "") != (in.QuoteCID == "") {
+		return atprotoPostPlan{}, fmt.Errorf("quote_uri and quote_cid are required together")
 	}
 
-	// Build post record.
 	record := map[string]any{
 		"$type":     "app.bsky.feed.post",
 		"text":      in.Text,
-		"createdAt": time.Now().UTC().Format(time.RFC3339),
+		"createdAt": now.Format(time.RFC3339),
 	}
 
 	// Reply block. root defaults to parent for top-level replies; must be set
@@ -481,12 +519,12 @@ func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 	var imagesEmbed map[string]any
 	if len(in.Images) > 0 {
 		if len(in.Images) > 4 {
-			return ToolResult{OK: false, Output: "atproto: at most 4 images per post"}, nil
+			return atprotoPostPlan{}, fmt.Errorf("atproto: at most 4 images per post")
 		}
 		items := make([]map[string]any, len(in.Images))
 		for i, img := range in.Images {
 			if img.CID == "" || img.Mime == "" || img.Size <= 0 {
-				return ToolResult{OK: false, Output: fmt.Sprintf("images[%d]: cid, mime, and size are required", i)}, nil
+				return atprotoPostPlan{}, fmt.Errorf("images[%d]: cid, mime, and size are required", i)
 			}
 			items[i] = map[string]any{
 				"alt": img.Alt,
@@ -525,24 +563,44 @@ func (t *atprotoPostTool) Exec(_ context.Context, _ ToolCallContext, args json.R
 		record["embed"] = quoteEmbed
 	}
 
-	payload := map[string]any{
-		"repo":       cli.session.DID,
-		"collection": "app.bsky.feed.post",
-		"record":     record,
-	}
-	data, err := cli.xrpcPost("com.atproto.repo.createRecord", payload)
-	if err != nil {
-		return ToolResult{OK: false, Output: err.Error()}, nil
-	}
+	return atprotoPostPlan{
+		Action:     "post",
+		Collection: "app.bsky.feed.post",
+		Record:     record,
+	}, nil
+}
 
-	var out struct {
-		URI string `json:"uri"`
-		CID string `json:"cid"`
+func atprotoPostPreviewResult(in atprotoPostArgs, account string, plan atprotoPostPlan, confirmRequired bool) ToolResult {
+	payload := map[string]any{
+		"ok":                   !confirmRequired,
+		"dry_run":              true,
+		"action":               plan.Action,
+		"account":              account,
+		"collection":           plan.Collection,
+		"record":               plan.Record,
+		"images":               len(in.Images),
+		"requires_confirm":     true,
+		"confirmation_example": map[string]bool{"confirm": true},
 	}
-	if err := json.Unmarshal(data, &out); err != nil {
-		return CapToolResult(ToolResult{OK: true, Output: string(data)}), nil
+	if confirmRequired {
+		payload["error"] = "atproto_post requires confirm=true to publish; this is a dry-run preview only"
+		payload["message"] = "No Bluesky record was created. Review the preview, then call atproto_post again with confirm=true to publish."
+	} else {
+		payload["message"] = "Dry-run preview only. No Bluesky record was created."
 	}
-	return CapToolResult(ToolResult{OK: true, Output: fmt.Sprintf("uri=%s cid=%s", out.URI, out.CID)}), nil
+	body, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return ToolResult{OK: false, Output: "preview marshal failed: " + err.Error()}
+	}
+	return CapToolResult(ToolResult{OK: !confirmRequired, Output: string(body), Stdout: string(body)})
+}
+
+func normalizedATProtoAccountName(account string) string {
+	account = strings.TrimSpace(account)
+	if account == "" {
+		return "main"
+	}
+	return account
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/atproto_client.go
+++ b/internal/tools/atproto_client.go
@@ -81,19 +81,29 @@ func (c *atProtoClient) login() error {
 		"identifier": c.cfg.Handle,
 		"password":   pw,
 	})
+	endpoint := atprotoSafetyEndpoint("com.atproto.server.createSession")
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return safetyErr
+	}
 	resp, err := c.httpCli.Post(
 		c.baseURL+"/xrpc/com.atproto.server.createSession",
 		"application/json",
 		bytes.NewReader(body),
 	)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return fmt.Errorf("atproto: login request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("atproto: login failed (%d): %s", resp.StatusCode, string(data))
+		cause := fmt.Errorf("atproto: login failed (%d): %s", resp.StatusCode, string(data))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.StatusCode), cause); safetyErr != nil {
+			return safetyErr
+		}
+		return cause
 	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
 	if err := json.Unmarshal(data, &c.session); err != nil {
 		return fmt.Errorf("atproto: parse session: %w", err)
 	}
@@ -102,12 +112,17 @@ func (c *atProtoClient) login() error {
 
 // xrpcGet performs a GET XRPC query.
 func (c *atProtoClient) xrpcGet(nsid string, params url.Values) ([]byte, error) {
+	endpoint := atprotoSafetyEndpoint(nsid)
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return nil, safetyErr
+	}
 	u := c.baseURL + "/xrpc/" + nsid
 	if len(params) > 0 {
 		u += "?" + params.Encode()
 	}
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, err
 	}
 	if c.session.AccessJwt != "" {
@@ -115,37 +130,55 @@ func (c *atProtoClient) xrpcGet(nsid string, params url.Values) ([]byte, error) 
 	}
 	resp, err := c.httpCli.Do(req)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, fmt.Errorf("atproto: GET %s: %w", nsid, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("atproto: GET %s (%d): %s", nsid, resp.StatusCode, string(data))
+		cause := fmt.Errorf("atproto: GET %s (%d): %s", nsid, resp.StatusCode, string(data))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.StatusCode), cause); safetyErr != nil {
+			return nil, safetyErr
+		}
+		return nil, cause
 	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
 	return data, nil
 }
 
 // xrpcPost performs a POST XRPC procedure.
 func (c *atProtoClient) xrpcPost(nsid string, payload any) ([]byte, error) {
+	endpoint := atprotoSafetyEndpoint(nsid)
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return nil, safetyErr
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, err
 	}
 	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/xrpc/"+nsid, bytes.NewReader(body))
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.session.AccessJwt)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpCli.Do(req)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, fmt.Errorf("atproto: POST %s: %w", nsid, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("atproto: POST %s (%d): %s", nsid, resp.StatusCode, string(data))
+		cause := fmt.Errorf("atproto: POST %s (%d): %s", nsid, resp.StatusCode, string(data))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.StatusCode), cause); safetyErr != nil {
+			return nil, safetyErr
+		}
+		return nil, cause
 	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
 	return data, nil
 }
 
@@ -160,8 +193,13 @@ type BlobInfo struct {
 // xrpcUploadBlob uploads a file to the PDS via com.atproto.repo.uploadBlob and
 // returns the resulting blob's CID, MIME type, and size.
 func (c *atProtoClient) xrpcUploadBlob(filename, mimeType string, data []byte) (BlobInfo, error) {
+	endpoint := atprotoSafetyEndpoint("com.atproto.repo.uploadBlob")
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return BlobInfo{}, safetyErr
+	}
 	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/xrpc/com.atproto.repo.uploadBlob", bytes.NewReader(data))
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return BlobInfo{}, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.session.AccessJwt)
@@ -170,14 +208,20 @@ func (c *atProtoClient) xrpcUploadBlob(filename, mimeType string, data []byte) (
 
 	resp, err := c.httpCli.Do(req)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return BlobInfo{}, fmt.Errorf("atproto: upload blob: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	respData, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return BlobInfo{}, fmt.Errorf("atproto: uploadBlob status %d: %s", resp.StatusCode, string(respData))
+		cause := fmt.Errorf("atproto: uploadBlob status %d: %s", resp.StatusCode, string(respData))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.StatusCode), cause); safetyErr != nil {
+			return BlobInfo{}, safetyErr
+		}
+		return BlobInfo{}, cause
 	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
 
 	var out struct {
 		Blob struct {

--- a/internal/tools/atproto_graph.go
+++ b/internal/tools/atproto_graph.go
@@ -77,14 +77,16 @@ func (t *atprotoGetFollowsTool) Exec(_ context.Context, _ ToolCallContext, args 
 	if in.Actor == "" {
 		return ToolResult{OK: false, Output: "actor is required"}, nil
 	}
-	if in.Limit <= 0 {
-		in.Limit = 50
-	}
+	in.Limit = clampExternalPageLimit(in.Limit, 50)
 
 	cli := newATProtoClient(t.cfg)
 	// getFollows is public, but we might need login if the PDS is restrictive or for higher limits.
 	// For now, try authenticated if we have credentials.
-	_ = cli.login()
+	if err := cli.login(); err != nil {
+		if output, ok := toolSafetyErrorOutput(err); ok {
+			return ToolResult{OK: false, Output: output}, nil
+		}
+	}
 
 	params := url.Values{
 		"actor": {in.Actor},
@@ -152,12 +154,14 @@ func (t *atprotoGetFollowersTool) Exec(_ context.Context, _ ToolCallContext, arg
 	if in.Actor == "" {
 		return ToolResult{OK: false, Output: "actor is required"}, nil
 	}
-	if in.Limit <= 0 {
-		in.Limit = 50
-	}
+	in.Limit = clampExternalPageLimit(in.Limit, 50)
 
 	cli := newATProtoClient(t.cfg)
-	_ = cli.login()
+	if err := cli.login(); err != nil {
+		if output, ok := toolSafetyErrorOutput(err); ok {
+			return ToolResult{OK: false, Output: output}, nil
+		}
+	}
 
 	params := url.Values{
 		"actor": {in.Actor},
@@ -222,7 +226,11 @@ func (t *atprotoGetProfileTool) Exec(_ context.Context, _ ToolCallContext, args 
 	}
 
 	cli := newATProtoClient(t.cfg)
-	_ = cli.login()
+	if err := cli.login(); err != nil {
+		if output, ok := toolSafetyErrorOutput(err); ok {
+			return ToolResult{OK: false, Output: output}, nil
+		}
+	}
 
 	params := url.Values{"actor": {in.Actor}}
 	data, err := cli.xrpcGet("app.bsky.actor.getProfile", params)
@@ -246,7 +254,7 @@ func ATProtoGraphExplorer(cfg *config.Config) Tool {
 
 func (t *atprotoGraphExplorerTool) Name() string { return "atproto_graph_explorer" }
 func (t *atprotoGraphExplorerTool) Description() string {
-	return "Explore and map a Bluesky user's social graph. Samples the accounts they follow, fetches who those accounts follow, and surfaces the most-connected people in their 2nd-degree network. Use this when asked to graph someone, explore their network, find follow suggestions, or analyze social connections."
+	return "Explore and map a Bluesky user's social graph. Samples the accounts they follow, fetches who those accounts follow, and surfaces the most-connected people in their 2nd-degree network. Each paginated request is capped at 100 items and protected by per-endpoint rate limits plus a circuit breaker."
 }
 func (t *atprotoGraphExplorerTool) DangerLevel() DangerLevel { return Safe }
 func (t *atprotoGraphExplorerTool) Effects() ToolEffects     { return ToolEffects{NeedsNetwork: true} }
@@ -287,12 +295,7 @@ func (t *atprotoGraphExplorerTool) Exec(_ context.Context, _ ToolCallContext, ar
 	if in.SampleSize > 25 {
 		in.SampleSize = 25
 	}
-	if in.FollowsLimit <= 0 {
-		in.FollowsLimit = 20
-	}
-	if in.FollowsLimit > 100 {
-		in.FollowsLimit = 100
-	}
+	in.FollowsLimit = clampExternalPageLimit(in.FollowsLimit, 20)
 
 	cli := newATProtoClient(t.cfg)
 	if err := cli.login(); err != nil {
@@ -312,6 +315,9 @@ func (t *atprotoGraphExplorerTool) Exec(_ context.Context, _ ToolCallContext, ar
 			"actor": {seedActor},
 		})
 		if err != nil {
+			if output, ok := toolSafetyErrorOutput(err); ok {
+				return ToolResult{OK: false, Output: output}, nil
+			}
 			return ToolResult{OK: false, Output: "failed to resolve actor: " + err.Error()}, nil
 		}
 		var profile struct {
@@ -332,6 +338,9 @@ func (t *atprotoGraphExplorerTool) Exec(_ context.Context, _ ToolCallContext, ar
 		"limit": {"100"},
 	})
 	if err != nil {
+		if output, ok := toolSafetyErrorOutput(err); ok {
+			return ToolResult{OK: false, Output: output}, nil
+		}
 		return ToolResult{OK: false, Output: "failed to get my follows: " + err.Error()}, nil
 	}
 
@@ -370,6 +379,9 @@ func (t *atprotoGraphExplorerTool) Exec(_ context.Context, _ ToolCallContext, ar
 			"limit": {fmt.Sprintf("%d", in.FollowsLimit)},
 		})
 		if err != nil {
+			if output, ok := toolSafetyErrorOutput(err); ok {
+				return ToolResult{OK: false, Output: output}, nil
+			}
 			continue // skip failures for individual accounts
 		}
 
@@ -515,6 +527,9 @@ func (t *atprotoCommunityDetectTool) Exec(_ context.Context, _ ToolCallContext, 
 		"limit": {"100"},
 	})
 	if err != nil {
+		if output, ok := toolSafetyErrorOutput(err); ok {
+			return ToolResult{OK: false, Output: output}, nil
+		}
 		return ToolResult{OK: false, Output: "failed to get follows: " + err.Error()}, nil
 	}
 
@@ -542,6 +557,9 @@ func (t *atprotoCommunityDetectTool) Exec(_ context.Context, _ ToolCallContext, 
 			"limit": {fmt.Sprintf("%d", in.FollowsLimit)},
 		})
 		if err != nil {
+			if output, ok := toolSafetyErrorOutput(err); ok {
+				return ToolResult{OK: false, Output: output}, nil
+			}
 			continue
 		}
 		var resp struct {

--- a/internal/tools/atproto_graph_test.go
+++ b/internal/tools/atproto_graph_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tripledoublev/v100/internal/config"
 )
@@ -119,6 +120,84 @@ func TestATProtoCommunityDetectClustersBySharedFollows(t *testing.T) {
 	}
 	if !strings.Contains(res.Output, "Xavier (@x.bsky.social) (2)") {
 		t.Fatalf("expected shared follow evidence: %s", res.Output)
+	}
+}
+
+func TestATProtoGraphExplorerReturnsSafetyAlertForSampleRateLimit(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+
+	mux := http.NewServeMux()
+	_, cfg := setupATProtoServer(t, mux)
+	mux.HandleFunc("/xrpc/app.bsky.graph.getFollows", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("actor") {
+		case "did:plc:test123":
+			_ = json.NewEncoder(w).Encode(map[string]any{"follows": []map[string]string{
+				{"did": "did:plc:a", "handle": "a.bsky.social", "displayName": "Alice"},
+			}})
+		case "did:plc:a":
+			http.Error(w, `{"error":"RateLimitExceeded"}`, http.StatusTooManyRequests)
+		default:
+			t.Fatalf("unexpected actor: %s", r.URL.Query().Get("actor"))
+		}
+	})
+
+	tool := ATProtoGraphExplorer(&config.Config{ATProto: cfg})
+	args, _ := json.Marshal(map[string]int{"sample_size": 1, "follows_limit": 10})
+	res, err := tool.Exec(t.Context(), ToolCallContext{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatalf("rate-limited sample fetch should fail with an alert, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, `"kind":"remote_rate_limit"`) {
+		t.Fatalf("expected structured remote_rate_limit alert, got: %s", res.Output)
+	}
+}
+
+func TestATProtoCommunityDetectReturnsSafetyAlertForSampleRateLimit(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+
+	mux := http.NewServeMux()
+	_, cfg := setupATProtoServer(t, mux)
+	mux.HandleFunc("/xrpc/app.bsky.graph.getFollows", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("actor") {
+		case "did:plc:test123":
+			_ = json.NewEncoder(w).Encode(map[string]any{"follows": []map[string]string{
+				{"did": "did:plc:a", "handle": "a.bsky.social", "displayName": "Alice"},
+			}})
+		case "did:plc:a":
+			http.Error(w, `{"error":"RateLimitExceeded"}`, http.StatusTooManyRequests)
+		default:
+			t.Fatalf("unexpected actor: %s", r.URL.Query().Get("actor"))
+		}
+	})
+
+	tool := ATProtoCommunityDetect(&config.Config{ATProto: cfg})
+	args, _ := json.Marshal(map[string]int{"sample_size": 1, "follows_limit": 10})
+	res, err := tool.Exec(t.Context(), ToolCallContext{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK {
+		t.Fatalf("rate-limited sample fetch should fail with an alert, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, `"kind":"remote_rate_limit"`) {
+		t.Fatalf("expected structured remote_rate_limit alert, got: %s", res.Output)
 	}
 }
 

--- a/internal/tools/atproto_rag.go
+++ b/internal/tools/atproto_rag.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,6 +15,8 @@ import (
 )
 
 const atprotoStoreName = "atproto"
+
+var atprotoResolverHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 // embedProvider returns the embedding provider from the call context,
 // preferring EmbedProvider over the chat Provider.
@@ -37,7 +38,7 @@ func ATProtoIndex(cfg *config.Config) Tool { return &atprotoIndexTool{cfg: cfg} 
 
 func (t *atprotoIndexTool) Name() string { return "atproto_index" }
 func (t *atprotoIndexTool) Description() string {
-	return "Fetch ATProto/Bluesky records (feed, notifications, a user profile, or a user's posts directly from their PDS) and store them as vector embeddings for later semantic retrieval with atproto_recall."
+	return "Fetch ATProto/Bluesky records (feed, notifications, a user profile, or a user's posts directly from their PDS) and store them as vector embeddings for later semantic retrieval with atproto_recall. Requests are capped at 100 records and protected by per-endpoint rate limits plus a circuit breaker."
 }
 func (t *atprotoIndexTool) DangerLevel() DangerLevel { return Safe }
 func (t *atprotoIndexTool) Effects() ToolEffects {
@@ -80,12 +81,7 @@ func (t *atprotoIndexTool) Exec(ctx context.Context, call ToolCallContext, args 
 	if err := json.Unmarshal(args, &in); err != nil {
 		return failResult(start, "invalid args: "+err.Error()), nil
 	}
-	if in.Limit <= 0 {
-		in.Limit = 20
-	}
-	if in.Limit > 100 {
-		in.Limit = 100
-	}
+	in.Limit = clampExternalPageLimit(in.Limit, 20)
 	ep := embedProvider(call)
 	if ep == nil {
 		return failResult(start, "no embedding provider available; use --embedding <provider>"), nil
@@ -177,6 +173,7 @@ func fetchUserPostsPDS(handle string, limit int) ([]indexRecord, error) {
 	if handle == "" {
 		return nil, fmt.Errorf("handle is required for source=user_posts")
 	}
+	limit = clampExternalPageLimit(limit, 20)
 
 	// 1. Resolve handle → DID (try appview first, then PLC/handle well-known)
 	did, err := resolveHandleToDID(handle)
@@ -198,14 +195,13 @@ func fetchUserPostsPDS(handle string, limit int) ([]indexRecord, error) {
 	}
 	u := pdsURL + "/xrpc/com.atproto.repo.listRecords?" + params.Encode()
 
-	resp, err := http.Get(u) //nolint:gosec // PDS URL is constructed from PLC directory
+	fetched, err := guardedExternalHTTPGetBody(atprotoResolverHTTPClient, atprotoSafetyEndpoint("com.atproto.repo.listRecords"), u)
 	if err != nil {
-		return nil, fmt.Errorf("fetch posts from PDS: %w", err)
+		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("PDS listRecords (%d): %s", resp.StatusCode, string(data))
+	data := fetched.Body
+	if fetched.Status != http.StatusOK {
+		return nil, fmt.Errorf("PDS listRecords (%d): %s", fetched.Status, string(data))
 	}
 
 	var listResp struct {
@@ -240,52 +236,52 @@ func fetchUserPostsPDS(handle string, limit int) ([]indexRecord, error) {
 // resolveHandleToDID resolves a Bluesky handle to its DID, trying multiple
 // methods: appview XRPC, PLC directory, and handle well-known.
 func resolveHandleToDID(handle string) (string, error) {
-	hc := &http.Client{Timeout: 10 * time.Second}
-
 	// Try appview resolveHandle
 	u := "https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=" + url.QueryEscape(handle)
-	resp, err := hc.Get(u)
-	if err == nil {
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode == http.StatusOK {
-			var out struct {
-				DID string `json:"did"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&out); err == nil && out.DID != "" {
-				return out.DID, nil
-			}
+	resp, err := guardedExternalHTTPGetBody(atprotoResolverHTTPClient, atprotoSafetyEndpoint("com.atproto.identity.resolveHandle"), u)
+	if err != nil {
+		if _, ok := toolSafetyErrorOutput(err); ok {
+			return "", err
+		}
+	} else if resp.Status == http.StatusOK {
+		var out struct {
+			DID string `json:"did"`
+		}
+		if err := json.Unmarshal(resp.Body, &out); err == nil && out.DID != "" {
+			return out.DID, nil
 		}
 	}
 
 	// Try handle well-known
-	resp2, err := hc.Get("https://" + handle + "/.well-known/atproto-did")
-	if err == nil {
-		defer func() { _ = resp2.Body.Close() }()
-		if resp2.StatusCode == http.StatusOK {
-			body, _ := io.ReadAll(resp2.Body)
-			did := strings.TrimSpace(string(body))
-			if strings.HasPrefix(did, "did:") {
-				return did, nil
-			}
+	resp, err = guardedExternalHTTPGetBody(atprotoResolverHTTPClient, atprotoSafetyEndpoint("identity.well-known"), "https://"+handle+"/.well-known/atproto-did")
+	if err != nil {
+		if _, ok := toolSafetyErrorOutput(err); ok {
+			return "", err
+		}
+	} else if resp.Status == http.StatusOK {
+		did := strings.TrimSpace(string(resp.Body))
+		if strings.HasPrefix(did, "did:") {
+			return did, nil
 		}
 	}
 
 	// Try DNS TXT record via DNS-over-HTTPS
-	resp3, err := hc.Get("https://dns.google/resolve?name=_atproto." + handle + "&type=TXT")
-	if err == nil {
-		defer func() { _ = resp3.Body.Close() }()
-		if resp3.StatusCode == http.StatusOK {
-			var dnsResp struct {
-				Answer []struct {
-					Data string `json:"data"`
-				} `json:"Answer"`
-			}
-			if err := json.NewDecoder(resp3.Body).Decode(&dnsResp); err == nil {
-				for _, a := range dnsResp.Answer {
-					d := strings.Trim(a.Data, `"`)
-					if strings.HasPrefix(d, "did=") {
-						return strings.TrimPrefix(d, "did="), nil
-					}
+	resp, err = guardedExternalHTTPGetBody(atprotoResolverHTTPClient, atprotoSafetyEndpoint("dns.google.resolve"), "https://dns.google/resolve?name=_atproto."+handle+"&type=TXT")
+	if err != nil {
+		if _, ok := toolSafetyErrorOutput(err); ok {
+			return "", err
+		}
+	} else if resp.Status == http.StatusOK {
+		var dnsResp struct {
+			Answer []struct {
+				Data string `json:"data"`
+			} `json:"Answer"`
+		}
+		if err := json.Unmarshal(resp.Body, &dnsResp); err == nil {
+			for _, a := range dnsResp.Answer {
+				d := strings.Trim(a.Data, `"`)
+				if strings.HasPrefix(d, "did=") {
+					return strings.TrimPrefix(d, "did="), nil
 				}
 			}
 		}
@@ -300,14 +296,13 @@ func resolvePDSEndpoint(did string) (string, error) {
 		return "", fmt.Errorf("unsupported DID method: %s (only did:plc is supported)", did)
 	}
 	u := "https://plc.directory/" + did
-	resp, err := http.Get(u) //nolint:gosec // PLC directory URL is well-known
+	resp, err := guardedExternalHTTPGetBody(atprotoResolverHTTPClient, atprotoSafetyEndpoint("plc.directory.resolveDID"), u)
 	if err != nil {
-		return "", fmt.Errorf("PLC directory lookup: %w", err)
+		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("PLC directory (%d): %s", resp.StatusCode, string(data))
+	data := resp.Body
+	if resp.Status != http.StatusOK {
+		return "", fmt.Errorf("PLC directory (%d): %s", resp.Status, string(data))
 	}
 
 	var doc struct {

--- a/internal/tools/atproto_rag_test.go
+++ b/internal/tools/atproto_rag_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func replaceATProtoResolverHTTPClientForTest(t *testing.T, client *http.Client) {
+	t.Helper()
+	old := atprotoResolverHTTPClient
+	atprotoResolverHTTPClient = client
+	t.Cleanup(func() {
+		atprotoResolverHTTPClient = old
+	})
+}
+
+func TestResolveHandleToDIDRateLimitStopsWithSafetyAlert(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+	requests := 0
+	replaceATProtoResolverHTTPClientForTest(t, &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"RateLimitExceeded"}`)),
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	_, err := resolveHandleToDID("alice.example")
+	if err == nil {
+		t.Fatal("expected resolver rate limit to fail")
+	}
+	var safetyErr *toolSafetyError
+	if !errors.As(err, &safetyErr) {
+		t.Fatalf("expected toolSafetyError, got %T: %v", err, err)
+	}
+	if safetyErr.alert.Kind != "remote_rate_limit" {
+		t.Fatalf("alert kind = %q, want remote_rate_limit", safetyErr.alert.Kind)
+	}
+	if requests != 1 {
+		t.Fatalf("rate-limited appview resolver should stop before fallback requests, got %d requests", requests)
+	}
+}

--- a/internal/tools/atproto_test.go
+++ b/internal/tools/atproto_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tripledoublev/v100/internal/config"
 )
@@ -437,7 +438,7 @@ func TestATProtoPost_PlainPost(t *testing.T) {
 
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
-	args, _ := json.Marshal(map[string]string{"text": "Hello Bluesky!"})
+	args, _ := json.Marshal(map[string]any{"text": "Hello Bluesky!", "confirm": true})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -453,6 +454,49 @@ func TestATProtoPost_PlainPost(t *testing.T) {
 	}
 }
 
+func TestATProtoPost_RequiresConfirmationPreviewDoesNotPublish(t *testing.T) {
+	mux := http.NewServeMux()
+	_, cfg := setupATProtoServer(t, mux)
+	createCalled := false
+	mux.HandleFunc("/xrpc/com.atproto.repo.createRecord", func(w http.ResponseWriter, _ *http.Request) {
+		createCalled = true
+		http.Error(w, "should not publish without confirm", http.StatusInternalServerError)
+	})
+
+	fullCfg := &config.Config{ATProto: cfg}
+	tool := ATProtoPost(fullCfg)
+	args, _ := json.Marshal(map[string]string{"text": "preview only"})
+	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OK {
+		t.Fatalf("missing confirm should return OK=false so callers know nothing was posted: %s", result.Output)
+	}
+	if createCalled {
+		t.Fatal("createRecord should not be called without confirm=true")
+	}
+	if !strings.Contains(result.Output, `"dry_run": true`) || !strings.Contains(result.Output, "requires confirm=true") {
+		t.Fatalf("expected clear dry-run preview and confirmation guidance, got: %s", result.Output)
+	}
+}
+
+func TestATProtoPost_ExplicitDryRunPreviewIsOK(t *testing.T) {
+	fullCfg := &config.Config{ATProto: config.ATProtoConfig{Handle: "unused.bsky.social"}}
+	tool := ATProtoPost(fullCfg)
+	args, _ := json.Marshal(map[string]any{"text": "preview only", "dry_run": true})
+	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("explicit dry_run should succeed without publishing: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, `"collection": "app.bsky.feed.post"`) {
+		t.Fatalf("expected post collection preview, got: %s", result.Output)
+	}
+}
+
 func TestATProtoPost_Repost(t *testing.T) {
 	mux := http.NewServeMux()
 	_, cfg := setupATProtoServer(t, mux)
@@ -465,10 +509,11 @@ func TestATProtoPost_Repost(t *testing.T) {
 
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
-	args, _ := json.Marshal(map[string]string{
+	args, _ := json.Marshal(map[string]any{
 		"text":       "ignored",
 		"repost_uri": "at://did:plc:other/app.bsky.feed.post/orig",
 		"repost_cid": "bafyorigcid",
+		"confirm":    true,
 	})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
@@ -503,10 +548,11 @@ func TestATProtoPost_ReplyRootDefaultsToParent(t *testing.T) {
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
 	// Top-level reply: only reply_to_* set, no root_* — root should default to parent.
-	args, _ := json.Marshal(map[string]string{
+	args, _ := json.Marshal(map[string]any{
 		"text":         "replying here",
 		"reply_to_uri": "at://did:plc:other/app.bsky.feed.post/parent",
 		"reply_to_cid": "parentcid",
+		"confirm":      true,
 	})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
@@ -546,12 +592,13 @@ func TestATProtoPost_ReplyNestedExplicitRoot(t *testing.T) {
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
 	// Nested reply: root_* differs from reply_to_* (thread root ≠ immediate parent).
-	args, _ := json.Marshal(map[string]string{
+	args, _ := json.Marshal(map[string]any{
 		"text":         "nested reply",
 		"reply_to_uri": "at://did:plc:other/app.bsky.feed.post/middle",
 		"reply_to_cid": "middlecid",
 		"root_uri":     "at://did:plc:other/app.bsky.feed.post/root",
 		"root_cid":     "rootcid",
+		"confirm":      true,
 	})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
@@ -590,10 +637,11 @@ func TestATProtoPost_QuotePost(t *testing.T) {
 
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
-	args, _ := json.Marshal(map[string]string{
+	args, _ := json.Marshal(map[string]any{
 		"text":      "great take",
 		"quote_uri": "at://did:plc:other/app.bsky.feed.post/orig",
 		"quote_cid": "origcid",
+		"confirm":   true,
 	})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
@@ -635,6 +683,7 @@ func TestATProtoPost_ImageOnlyPost(t *testing.T) {
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
 	args, _ := json.Marshal(map[string]any{
+		"confirm": true,
 		"images": []map[string]any{{
 			"cid":  "bafkimg",
 			"mime": "image/png",
@@ -689,6 +738,7 @@ func TestATProtoPost_QuoteWithImagesUsesRecordWithMedia(t *testing.T) {
 		"text":      "quote with image",
 		"quote_uri": "at://did:plc:other/app.bsky.feed.post/orig",
 		"quote_cid": "origcid",
+		"confirm":   true,
 		"images": []map[string]any{{
 			"cid":  "bafkimg",
 			"mime": "image/jpeg",
@@ -735,9 +785,10 @@ func TestATProtoPost_RepostSubjectPayload(t *testing.T) {
 
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
-	args, _ := json.Marshal(map[string]string{
+	args, _ := json.Marshal(map[string]any{
 		"repost_uri": "at://did:plc:other/app.bsky.feed.post/tgt",
 		"repost_cid": "tgtcid",
+		"confirm":    true,
 	})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
@@ -767,7 +818,7 @@ func TestATProtoPost_ServerError(t *testing.T) {
 
 	fullCfg := &config.Config{ATProto: cfg}
 	tool := ATProtoPost(fullCfg)
-	args, _ := json.Marshal(map[string]string{"text": "will fail"})
+	args, _ := json.Marshal(map[string]any{"text": "will fail", "confirm": true})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
 		t.Fatalf("unexpected Go error (should be OK=false): %v", err)
@@ -777,6 +828,58 @@ func TestATProtoPost_ServerError(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "400") {
 		t.Errorf("expected HTTP status in error output, got: %s", result.Output)
+	}
+}
+
+func TestATProtoPost_RateLimitOpensCircuitBreaker(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+
+	mux := http.NewServeMux()
+	_, cfg := setupATProtoServer(t, mux)
+	createCalls := 0
+	mux.HandleFunc("/xrpc/com.atproto.repo.createRecord", func(w http.ResponseWriter, _ *http.Request) {
+		createCalls++
+		http.Error(w, `{"error":"RateLimitExceeded"}`, http.StatusTooManyRequests)
+	})
+
+	fullCfg := &config.Config{ATProto: cfg}
+	tool := ATProtoPost(fullCfg)
+	args, _ := json.Marshal(map[string]any{"text": "too much", "confirm": true})
+
+	var result ToolResult
+	for i := 0; i < 3; i++ {
+		var err error
+		result, err = tool.Exec(context.Background(), emptyCallCtx(), args)
+		if err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i+1, err)
+		}
+		if result.OK {
+			t.Fatalf("rate-limited call %d should fail, got: %s", i+1, result.Output)
+		}
+	}
+	if !strings.Contains(result.Output, `"kind":"circuit_breaker_open"`) {
+		t.Fatalf("third rate-limit response should open circuit breaker, got: %s", result.Output)
+	}
+
+	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
+	if err != nil {
+		t.Fatalf("unexpected error after breaker opened: %v", err)
+	}
+	if result.OK {
+		t.Fatalf("open breaker should block publishing, got: %s", result.Output)
+	}
+	if createCalls != 3 {
+		t.Fatalf("fourth call should be blocked before createRecord, createCalls=%d", createCalls)
+	}
+	if !strings.Contains(result.Output, `"kind":"circuit_breaker_open"`) {
+		t.Fatalf("expected structured circuit breaker alert, got: %s", result.Output)
 	}
 }
 
@@ -999,7 +1102,7 @@ func TestATProtoPost_AltAccount(t *testing.T) {
 		ATProtoAlt: config.ATProtoConfig{Handle: "alt.art", AppPassword: "pw-alt", PDSURL: srv.URL},
 	}
 	tool := ATProtoPost(cfg)
-	args, _ := json.Marshal(map[string]string{"text": "hello from alt", "account": "alt"})
+	args, _ := json.Marshal(map[string]any{"text": "hello from alt", "account": "alt", "confirm": true})
 	result, err := tool.Exec(context.Background(), emptyCallCtx(), args)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/tools/news.go
+++ b/internal/tools/news.go
@@ -42,10 +42,11 @@ type newsItem struct {
 }
 
 type newsFailure struct {
-	Source string `json:"source"`
-	URL    string `json:"url"`
-	Error  string `json:"error"`
-	Status int    `json:"status,omitempty"`
+	Source string           `json:"source"`
+	URL    string           `json:"url"`
+	Error  string           `json:"error"`
+	Status int              `json:"status,omitempty"`
+	Alert  *toolSafetyAlert `json:"alert,omitempty"`
 }
 
 type newsFetchOutput struct {
@@ -166,7 +167,7 @@ func NewsFetch() Tool { return &newsFetchTool{} }
 
 func (t *newsFetchTool) Name() string { return "news_fetch" }
 func (t *newsFetchTool) Description() string {
-	return "Fetch current news as normalized headline items. Uses feeds first when available, then source-aware headline extraction, and reports blocked or thin sources explicitly."
+	return "Fetch current news as normalized headline items. Uses feeds first when available, then source-aware headline extraction, and reports blocked or thin sources explicitly. max_items is capped at 100 per call; each source is protected by per-endpoint rate limits plus a circuit breaker."
 }
 func (t *newsFetchTool) DangerLevel() DangerLevel { return Safe }
 func (t *newsFetchTool) Effects() ToolEffects {
@@ -181,7 +182,7 @@ func (t *newsFetchTool) InputSchema() json.RawMessage {
 			"topic": {"type": "string", "description": "Optional topic hint such as general, politics, business, markets, or tech."},
 			"language": {"type": "string", "description": "Preferred language: en, fr, or any.", "default": "any"},
 			"sources": {"type": "array", "items": {"type": "string"}, "description": "Optional explicit source names or URLs. If omitted, sensible defaults are chosen for the region/topic."},
-			"max_items": {"type": "integer", "description": "Maximum number of headlines to return.", "default": 8},
+			"max_items": {"type": "integer", "description": "Maximum number of headlines to return (1-100, default 8).", "default": 8},
 			"fresh_hours": {"type": "integer", "description": "If positive, prefer items published within this many hours when timestamps are available.", "default": 24},
 			"fresh": {"type": "boolean", "description": "Force a fresh fetch, bypassing intermediate caches.", "default": false}
 		}
@@ -223,7 +224,8 @@ func (t *newsFetchTool) OutputSchema() json.RawMessage {
 						"source": {"type": "string"},
 						"url": {"type": "string"},
 						"error": {"type": "string"},
-						"status": {"type": "integer"}
+						"status": {"type": "integer"},
+						"alert": {"type": "object", "description": "Structured rate-limit or circuit-breaker alert when present."}
 					}
 				}
 			},
@@ -247,9 +249,7 @@ func (t *newsFetchTool) Exec(ctx context.Context, call ToolCallContext, args jso
 	a.Region = normalizeNewsToken(a.Region, "general")
 	a.Topic = normalizeNewsToken(a.Topic, "general")
 	a.Language = normalizeNewsLanguage(a.Language)
-	if a.MaxItems <= 0 || a.MaxItems > 20 {
-		a.MaxItems = 8
-	}
+	a.MaxItems = clampExternalPageLimit(a.MaxItems, 8)
 	if a.FreshHours < 0 || a.FreshHours > 24*14 {
 		a.FreshHours = 24
 	}
@@ -358,15 +358,31 @@ func (t *newsFetchTool) Exec(ctx context.Context, call ToolCallContext, args jso
 
 func fetchNewsSource(ctx context.Context, call ToolCallContext, req newsSourceRequest, freshHours int, fresh bool) ([]newsItem, newsFailure) {
 	start := time.Now()
+	endpoint := newsSafetyEndpoint(req.URL)
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return nil, newsFailure{Source: req.Name, URL: req.URL, Error: safetyErr.alert.Message, Alert: &safetyErr.alert}
+	}
 	resp, fail, err := fetchHTTP(ctx, call, start, req.URL, 256*1024, fresh)
 	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, newsFailure{Source: req.Name, URL: req.URL, Error: err.Error()}
 	}
 	if fail != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
 		return nil, newsFailure{Source: req.Name, URL: req.URL, Error: fail.Output}
 	}
 
 	if resp.status < 200 || resp.status >= 400 {
+		cause := fmt.Errorf("news_fetch: %s returned HTTP %d: %s", req.Name, resp.status, classifyNewsHTTPFailure(resp))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.status), cause); safetyErr != nil {
+			return nil, newsFailure{
+				Source: req.Name,
+				URL:    req.URL,
+				Status: resp.status,
+				Error:  safetyErr.alert.Message,
+				Alert:  &safetyErr.alert,
+			}
+		}
 		return nil, newsFailure{
 			Source: req.Name,
 			URL:    req.URL,
@@ -374,6 +390,7 @@ func fetchNewsSource(ctx context.Context, call ToolCallContext, req newsSourceRe
 			Error:  classifyNewsHTTPFailure(resp),
 		}
 	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
 
 	bodyText := string(resp.body)
 	var (

--- a/internal/tools/news_test.go
+++ b/internal/tools/news_test.go
@@ -81,6 +81,85 @@ func TestNewsFetchExecParsesRSSAndFiltersFreshItems(t *testing.T) {
 	}
 }
 
+func TestNewsFetchClampsMaxItemsTo100(t *testing.T) {
+	feedURL := "https://fixture.example/large-feed.xml"
+	var feed strings.Builder
+	feed.WriteString(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Fixture News</title>`)
+	for i := 0; i < 105; i++ {
+		fmt.Fprintf(&feed, `<item><title>City plan item %03d</title></item>`, i)
+	}
+	feed.WriteString(`</channel></rss>`)
+	session := &routingFakeDockerSession{
+		routes: map[string]executor.Result{
+			feedURL: {
+				ExitCode: 0,
+				Stdout:   "200\napplication/rss+xml\n\n__V100_CURL_BODY__\n" + feed.String(),
+			},
+		},
+	}
+
+	args, err := json.Marshal(map[string]any{
+		"sources":     []string{feedURL},
+		"max_items":   150,
+		"fresh_hours": 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := NewsFetch().Exec(context.Background(), ToolCallContext{Session: session}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Fatalf("news_fetch failed: %s", res.Output)
+	}
+	var out newsFetchOutput
+	if err := json.Unmarshal([]byte(res.Output), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Items) != 100 {
+		t.Fatalf("expected max_items to clamp at 100, got %d", len(out.Items))
+	}
+}
+
+func TestNewsFetchRateLimitCircuitBreakerFailureIsStructured(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+	feedURL := "https://fixture.example/rate-limited.xml"
+	session := &routingFakeDockerSession{
+		routes: map[string]executor.Result{
+			feedURL: {
+				ExitCode: 0,
+				Stdout:   "429\ntext/plain\n\n__V100_CURL_BODY__\nrate limit exceeded",
+			},
+		},
+	}
+	args, err := json.Marshal(map[string]any{"sources": []string{feedURL}, "max_items": 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var res ToolResult
+	for i := 0; i < 3; i++ {
+		res, err = NewsFetch().Exec(context.Background(), ToolCallContext{Session: session}, args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.OK {
+			t.Fatalf("rate-limited fetch should fail, got: %s", res.Output)
+		}
+	}
+	if !strings.Contains(res.Output, "circuit_breaker_open") {
+		t.Fatalf("expected structured circuit-breaker alert in output, got: %s", res.Output)
+	}
+}
+
 func TestNewsFetchExecExtractsJSONLDHeadlines(t *testing.T) {
 	now := time.Now().UTC()
 	pageURL := "https://fixture.example/frontpage"
@@ -338,7 +417,6 @@ func (s *routingFakeDockerSession) Run(_ context.Context, req executor.RunReques
 	}
 	return executor.Result{ExitCode: 1, Stderr: "unexpected url: " + url}, nil
 }
-
 
 func TestResolveNewsSourceRequestsQuebecFrench(t *testing.T) {
 	reqs := resolveNewsSourceRequests(newsFetchArgs{

--- a/internal/tools/tool_safety.go
+++ b/internal/tools/tool_safety.go
@@ -1,0 +1,286 @@
+package tools
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxExternalItemsPerCall = 100
+
+type externalAPISafetyPolicy struct {
+	RatePerSecond            float64
+	Burst                    int
+	BreakerThreshold         int
+	BreakerBaseBackoff       time.Duration
+	BreakerMaxBackoff        time.Duration
+	MaxConsecutiveShiftPower int
+}
+
+type externalAPISafety struct {
+	mu        sync.Mutex
+	now       func() time.Time
+	policy    externalAPISafetyPolicy
+	endpoints map[string]*externalEndpointSafety
+}
+
+type externalEndpointSafety struct {
+	tokens                     float64
+	updatedAt                  time.Time
+	consecutiveRateLimitErrors int
+	backoffUntil               time.Time
+}
+
+type toolSafetyError struct {
+	alert toolSafetyAlert
+	cause error
+}
+
+type toolSafetyAlert struct {
+	Kind                       string `json:"kind"`
+	Endpoint                   string `json:"endpoint"`
+	Message                    string `json:"message"`
+	RetryAfterMS               int64  `json:"retry_after_ms,omitempty"`
+	BackoffUntil               string `json:"backoff_until,omitempty"`
+	ConsecutiveRateLimitErrors int    `json:"consecutive_rate_limit_errors,omitempty"`
+}
+
+var defaultExternalAPISafety = newExternalAPISafety(time.Now, externalAPISafetyPolicy{
+	RatePerSecond:            5,
+	Burst:                    100,
+	BreakerThreshold:         3,
+	BreakerBaseBackoff:       30 * time.Second,
+	BreakerMaxBackoff:        15 * time.Minute,
+	MaxConsecutiveShiftPower: 10,
+})
+
+func clampExternalPageLimit(requested, defaultLimit int) int {
+	if requested <= 0 {
+		return defaultLimit
+	}
+	if requested > maxExternalItemsPerCall {
+		return maxExternalItemsPerCall
+	}
+	return requested
+}
+
+func newExternalAPISafety(now func() time.Time, policy externalAPISafetyPolicy) *externalAPISafety {
+	if now == nil {
+		now = time.Now
+	}
+	if policy.RatePerSecond <= 0 {
+		policy.RatePerSecond = 1
+	}
+	if policy.Burst <= 0 {
+		policy.Burst = 1
+	}
+	if policy.BreakerThreshold <= 0 {
+		policy.BreakerThreshold = 3
+	}
+	if policy.BreakerBaseBackoff <= 0 {
+		policy.BreakerBaseBackoff = time.Second
+	}
+	if policy.BreakerMaxBackoff <= 0 {
+		policy.BreakerMaxBackoff = policy.BreakerBaseBackoff
+	}
+	if policy.MaxConsecutiveShiftPower <= 0 {
+		policy.MaxConsecutiveShiftPower = 10
+	}
+	return &externalAPISafety{
+		now:       now,
+		policy:    policy,
+		endpoints: make(map[string]*externalEndpointSafety),
+	}
+}
+
+func (s *externalAPISafety) before(endpoint string) *toolSafetyError {
+	if s == nil {
+		return nil
+	}
+	endpoint = normalizeExternalEndpoint(endpoint)
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.endpointLocked(endpoint, now)
+	s.refillLocked(state, now)
+
+	if state.backoffUntil.After(now) {
+		return newToolSafetyError(toolSafetyAlert{
+			Kind:                       "circuit_breaker_open",
+			Endpoint:                   endpoint,
+			Message:                    "external API circuit breaker is open after repeated rate-limit responses",
+			RetryAfterMS:               int64(math.Ceil(float64(state.backoffUntil.Sub(now)) / float64(time.Millisecond))),
+			BackoffUntil:               state.backoffUntil.UTC().Format(time.RFC3339),
+			ConsecutiveRateLimitErrors: state.consecutiveRateLimitErrors,
+		}, nil)
+	}
+
+	if state.tokens < 1 {
+		wait := time.Duration(math.Ceil((1-state.tokens)/s.policy.RatePerSecond*1000)) * time.Millisecond
+		return newToolSafetyError(toolSafetyAlert{
+			Kind:         "rate_limit_exceeded",
+			Endpoint:     endpoint,
+			Message:      "external API endpoint rate limit exceeded before request",
+			RetryAfterMS: int64(wait / time.Millisecond),
+		}, nil)
+	}
+
+	state.tokens--
+	return nil
+}
+
+func (s *externalAPISafety) after(endpoint string, rateLimited bool, cause error) *toolSafetyError {
+	if s == nil {
+		return nil
+	}
+	endpoint = normalizeExternalEndpoint(endpoint)
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.endpointLocked(endpoint, now)
+	if !rateLimited {
+		state.consecutiveRateLimitErrors = 0
+		return nil
+	}
+
+	state.consecutiveRateLimitErrors++
+	alert := toolSafetyAlert{
+		Kind:                       "remote_rate_limit",
+		Endpoint:                   endpoint,
+		Message:                    "external API returned a rate-limit response",
+		ConsecutiveRateLimitErrors: state.consecutiveRateLimitErrors,
+	}
+
+	if state.consecutiveRateLimitErrors >= s.policy.BreakerThreshold {
+		shift := state.consecutiveRateLimitErrors - s.policy.BreakerThreshold
+		if shift > s.policy.MaxConsecutiveShiftPower {
+			shift = s.policy.MaxConsecutiveShiftPower
+		}
+		backoff := s.policy.BreakerBaseBackoff * time.Duration(1<<shift)
+		if backoff > s.policy.BreakerMaxBackoff {
+			backoff = s.policy.BreakerMaxBackoff
+		}
+		state.backoffUntil = now.Add(backoff)
+		alert.Kind = "circuit_breaker_open"
+		alert.Message = "external API circuit breaker opened after repeated rate-limit responses"
+		alert.RetryAfterMS = int64(backoff / time.Millisecond)
+		alert.BackoffUntil = state.backoffUntil.UTC().Format(time.RFC3339)
+	}
+
+	return newToolSafetyError(alert, cause)
+}
+
+func (s *externalAPISafety) endpointLocked(endpoint string, now time.Time) *externalEndpointSafety {
+	state := s.endpoints[endpoint]
+	if state == nil {
+		state = &externalEndpointSafety{tokens: float64(s.policy.Burst), updatedAt: now}
+		s.endpoints[endpoint] = state
+	}
+	return state
+}
+
+func (s *externalAPISafety) refillLocked(state *externalEndpointSafety, now time.Time) {
+	elapsed := now.Sub(state.updatedAt).Seconds()
+	if elapsed > 0 {
+		state.tokens += elapsed * s.policy.RatePerSecond
+		if burst := float64(s.policy.Burst); state.tokens > burst {
+			state.tokens = burst
+		}
+		state.updatedAt = now
+	}
+}
+
+func normalizeExternalEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "external:unknown"
+	}
+	return endpoint
+}
+
+func newToolSafetyError(alert toolSafetyAlert, cause error) *toolSafetyError {
+	return &toolSafetyError{alert: alert, cause: cause}
+}
+
+func toolSafetyErrorOutput(err error) (string, bool) {
+	var safetyErr *toolSafetyError
+	if errors.As(err, &safetyErr) {
+		return safetyErr.Error(), true
+	}
+	return "", false
+}
+
+func (e *toolSafetyError) Error() string {
+	payload := map[string]any{
+		"ok":    false,
+		"alert": e.alert,
+	}
+	if e.cause != nil {
+		payload["error"] = e.cause.Error()
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		if e.cause != nil {
+			return fmt.Sprintf("%s: %s", e.alert.Message, e.cause)
+		}
+		return e.alert.Message
+	}
+	return string(body)
+}
+
+func atprotoSafetyEndpoint(nsid string) string {
+	return "atproto:" + strings.TrimSpace(nsid)
+}
+
+func newsSafetyEndpoint(rawURL string) string {
+	return "news_fetch:" + strings.TrimSpace(rawURL)
+}
+
+func isHTTPRateLimitStatus(status int) bool {
+	return status == http.StatusTooManyRequests
+}
+
+type guardedHTTPBody struct {
+	Status int
+	Body   []byte
+}
+
+func guardedExternalHTTPGetBody(client *http.Client, endpoint, rawURL string) (guardedHTTPBody, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if safetyErr := defaultExternalAPISafety.before(endpoint); safetyErr != nil {
+		return guardedHTTPBody{}, safetyErr
+	}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
+		return guardedHTTPBody{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = defaultExternalAPISafety.after(endpoint, false, nil)
+		return guardedHTTPBody{Status: resp.StatusCode}, err
+	}
+	out := guardedHTTPBody{Status: resp.StatusCode, Body: data}
+	if resp.StatusCode != http.StatusOK {
+		cause := fmt.Errorf("external GET %s (%d): %s", endpoint, resp.StatusCode, string(data))
+		if safetyErr := defaultExternalAPISafety.after(endpoint, isHTTPRateLimitStatus(resp.StatusCode), cause); safetyErr != nil {
+			return out, safetyErr
+		}
+		return out, nil
+	}
+	_ = defaultExternalAPISafety.after(endpoint, false, nil)
+	return out, nil
+}

--- a/internal/tools/tool_safety_test.go
+++ b/internal/tools/tool_safety_test.go
@@ -1,0 +1,194 @@
+package tools
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func replaceDefaultExternalAPISafetyForTest(t *testing.T, safety *externalAPISafety) {
+	t.Helper()
+	old := defaultExternalAPISafety
+	defaultExternalAPISafety = safety
+	t.Cleanup(func() {
+		defaultExternalAPISafety = old
+	})
+}
+
+func TestClampExternalPageLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		requested    int
+		defaultLimit int
+		want         int
+	}{
+		{name: "default", requested: 0, defaultLimit: 20, want: 20},
+		{name: "negative", requested: -5, defaultLimit: 8, want: 8},
+		{name: "inside cap", requested: 42, defaultLimit: 8, want: 42},
+		{name: "above cap", requested: 250, defaultLimit: 8, want: 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampExternalPageLimit(tt.requested, tt.defaultLimit); got != tt.want {
+				t.Fatalf("clampExternalPageLimit(%d, %d) = %d, want %d", tt.requested, tt.defaultLimit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExternalAPISafetyEnforcesRateLimitPerEndpoint(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	safety := newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      1,
+		Burst:              2,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	})
+
+	if err := safety.before("news_fetch:https://example.com/rss"); err != nil {
+		t.Fatalf("first request should pass: %v", err)
+	}
+	if err := safety.before("news_fetch:https://example.com/rss"); err != nil {
+		t.Fatalf("second burst request should pass: %v", err)
+	}
+	if err := safety.before("news_fetch:https://example.com/rss"); err == nil {
+		t.Fatal("third request should be rate-limited")
+	} else if !strings.Contains(err.Error(), `"kind":"rate_limit_exceeded"`) {
+		t.Fatalf("rate-limit error should be structured, got: %s", err.Error())
+	}
+
+	if err := safety.before("news_fetch:https://other.example/rss"); err != nil {
+		t.Fatalf("different endpoint should have its own bucket: %v", err)
+	}
+
+	now = now.Add(time.Second)
+	if err := safety.before("news_fetch:https://example.com/rss"); err != nil {
+		t.Fatalf("token should refill after one second: %v", err)
+	}
+}
+
+func TestExternalAPISafetyCircuitBreakerBackoff(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	safety := newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      100,
+		Burst:              100,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: 2 * time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	})
+	endpoint := "atproto:app.bsky.feed.getTimeline"
+
+	for i := 0; i < 2; i++ {
+		if err := safety.before(endpoint); err != nil {
+			t.Fatalf("request %d should pass before breaker opens: %v", i+1, err)
+		}
+		err := safety.after(endpoint, true, errors.New("HTTP 429"))
+		if err == nil {
+			t.Fatalf("remote rate-limit response %d should produce a structured alert", i+1)
+		}
+		if !strings.Contains(err.Error(), `"kind":"remote_rate_limit"`) {
+			t.Fatalf("expected remote_rate_limit alert, got: %s", err.Error())
+		}
+	}
+
+	if err := safety.before(endpoint); err != nil {
+		t.Fatalf("third request should pass before recording the third remote 429: %v", err)
+	}
+	err := safety.after(endpoint, true, errors.New("HTTP 429"))
+	if err == nil {
+		t.Fatal("third remote 429 should open the breaker")
+	}
+	if got := err.Error(); !strings.Contains(got, `"kind":"circuit_breaker_open"`) || !strings.Contains(got, `"retry_after_ms":2000`) {
+		t.Fatalf("expected circuit breaker alert with 2s backoff, got: %s", got)
+	}
+
+	if err := safety.before(endpoint); err == nil {
+		t.Fatal("open breaker should block new requests")
+	} else if !strings.Contains(err.Error(), `"kind":"circuit_breaker_open"`) {
+		t.Fatalf("expected circuit breaker block, got: %s", err.Error())
+	}
+
+	now = now.Add(2 * time.Second)
+	if err := safety.before(endpoint); err != nil {
+		t.Fatalf("breaker should allow request after backoff: %v", err)
+	}
+	_ = safety.after(endpoint, false, nil)
+	if err := safety.before(endpoint); err != nil {
+		t.Fatalf("successful response should reset remote-rate-limit streak: %v", err)
+	}
+}
+
+func TestExternalAPISafetyDefaultsAndAlertFormatting(t *testing.T) {
+	safety := newExternalAPISafety(nil, externalAPISafetyPolicy{})
+	if safety.policy.RatePerSecond != 1 {
+		t.Fatalf("default rate = %v, want 1", safety.policy.RatePerSecond)
+	}
+	if safety.policy.Burst != 1 {
+		t.Fatalf("default burst = %d, want 1", safety.policy.Burst)
+	}
+	if safety.policy.BreakerThreshold != 3 {
+		t.Fatalf("default breaker threshold = %d, want 3", safety.policy.BreakerThreshold)
+	}
+	if safety.policy.BreakerBaseBackoff != time.Second {
+		t.Fatalf("default breaker base backoff = %s, want 1s", safety.policy.BreakerBaseBackoff)
+	}
+	if safety.policy.BreakerMaxBackoff != time.Second {
+		t.Fatalf("default breaker max backoff = %s, want 1s", safety.policy.BreakerMaxBackoff)
+	}
+	if safety.policy.MaxConsecutiveShiftPower != 10 {
+		t.Fatalf("default shift cap = %d, want 10", safety.policy.MaxConsecutiveShiftPower)
+	}
+	if got := normalizeExternalEndpoint(" "); got != "external:unknown" {
+		t.Fatalf("blank endpoint normalized to %q", got)
+	}
+	err := newToolSafetyError(toolSafetyAlert{Kind: "rate_limit_exceeded", Endpoint: "e", Message: "blocked"}, nil)
+	if got := err.Error(); !strings.Contains(got, `"kind":"rate_limit_exceeded"`) || strings.Contains(got, `"error"`) {
+		t.Fatalf("unexpected alert JSON: %s", got)
+	}
+}
+
+func TestGuardedExternalHTTPGetBodyRecordsSuccessAndNonRateStatus(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	replaceDefaultExternalAPISafetyForTest(t, newExternalAPISafety(func() time.Time { return now }, externalAPISafetyPolicy{
+		RatePerSecond:      10,
+		Burst:              10,
+		BreakerThreshold:   3,
+		BreakerBaseBackoff: time.Second,
+		BreakerMaxBackoff:  time.Minute,
+	}))
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			status := http.StatusOK
+			body := "ok"
+			if strings.Contains(req.URL.Path, "server-error") {
+				status = http.StatusInternalServerError
+				body = "try later"
+			}
+			return &http.Response{
+				StatusCode: status,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	got, err := guardedExternalHTTPGetBody(client, "test:success", "https://example.com/success")
+	if err != nil {
+		t.Fatalf("success request failed: %v", err)
+	}
+	if got.Status != http.StatusOK || string(got.Body) != "ok" {
+		t.Fatalf("success response = %+v body=%q", got, string(got.Body))
+	}
+	got, err = guardedExternalHTTPGetBody(client, "test:server-error", "https://example.com/server-error")
+	if err != nil {
+		t.Fatalf("non-rate HTTP status should be returned for caller handling, got: %v", err)
+	}
+	if got.Status != http.StatusInternalServerError || string(got.Body) != "try later" {
+		t.Fatalf("server-error response = %+v body=%q", got, string(got.Body))
+	}
+}

--- a/schemas/tools.json
+++ b/schemas/tools.json
@@ -141,7 +141,7 @@
     },
     "atproto_post": {
       "dangerous": true,
-      "input":  { "properties": { "text": { "type": "string" }, "reply_to_uri": { "type": "string" }, "reply_to_cid": { "type": "string" }, "root_uri": { "type": "string" }, "root_cid": { "type": "string" }, "quote_uri": { "type": "string" }, "quote_cid": { "type": "string" }, "repost_uri": { "type": "string" }, "repost_cid": { "type": "string" } } },
+      "input":  { "properties": { "text": { "type": "string" }, "reply_to_uri": { "type": "string" }, "reply_to_cid": { "type": "string" }, "root_uri": { "type": "string" }, "root_cid": { "type": "string" }, "quote_uri": { "type": "string" }, "quote_cid": { "type": "string" }, "repost_uri": { "type": "string" }, "repost_cid": { "type": "string" }, "dry_run": { "type": "boolean" }, "confirm": { "type": "boolean" } } },
       "output": { "properties": { "ok": { "type": "boolean" }, "uri": { "type": "string" }, "cid": { "type": "string" } } }
     },
     "atproto_resolve": {


### PR DESCRIPTION
## Summary
- add a shared external API safety guard for token-bucket rate limits, circuit breaker backoff, and structured alerts
- wire the guard into ATProto XRPC calls, direct PDS indexing, and news source fetches
- make `atproto_post` preview-only unless `confirm=true`, with `dry_run` support and updated schemas/docs

Closes #218.

## Verification
- `make lint`
- `env GOCACHE=/tmp/v100-issue218-gocache go test ./...`
- `env GOCACHE=/tmp/v100-issue218-gocache go build ./...`
- `env GOCACHE=/tmp/v100-issue218-gocache go test -coverprofile=/tmp/v100-issue218-tools.cover ./internal/tools`
- `tool_safety.go 92.0% (81/88 statements)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ATProto post publishing now requires explicit `confirm=true`; requests without confirmation return a preview instead
  * Added per-endpoint rate limiting, circuit breakers, and exponential backoff for external API calls
  * Pagination capped at 100 items per request with structured error alerts

* **Documentation**
  * Updated README documenting external API guardrails and safety mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->