### PR TITLE
fix: harden executor process lifecycle

### DIFF
--- a/.github/workflows/executor-hardening.yml
+++ b/.github/workflows/executor-hardening.yml
@@ -1,0 +1,33 @@
+name: Executor Hardening
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/executor-hardening.yml'
+      - 'internal/core/executor/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/executor-hardening.yml'
+      - 'internal/core/executor/**'
+  workflow_dispatch:
+
+env:
+  GOWORK: off
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Executor process and FD leak stress
+        run: go test -race ./internal/core/executor -run TestRunProcessStressNoZombieOrFDLeak -count=1

--- a/cmd/v100/cmd_admin.go
+++ b/cmd/v100/cmd_admin.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/tripledoublev/v100/internal/auth"
 	"github.com/tripledoublev/v100/internal/config"
+	"github.com/tripledoublev/v100/internal/core/executor"
 	"github.com/tripledoublev/v100/internal/policy"
 	"github.com/tripledoublev/v100/internal/providers"
 	"github.com/tripledoublev/v100/internal/tools"
@@ -388,6 +389,15 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 			} else {
 				fmt.Println(ui.OK("Sandbox backend: host"))
 			}
+			line, unhealthy, unavailable := executorResourceStatusLine()
+			if unhealthy {
+				fmt.Println(ui.Fail(line))
+				ok = false
+			} else if unavailable {
+				fmt.Println(ui.Warn(line))
+			} else {
+				fmt.Println(ui.OK(line))
+			}
 
 			printOAuthConfigStatus := func(name string, err error) {
 				credsPath := auth.DefaultCredentialsPath()
@@ -613,6 +623,28 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func executorResourceStatusLine() (string, bool, bool) {
+	stats, err := executor.CurrentResourceStats()
+	if err != nil {
+		return "Executor resources: unavailable (" + err.Error() + ")", false, true
+	}
+	line := fmt.Sprintf(
+		"Executor resources: open_fds=%d subprocesses=%d zombies=%d process_pool=%d/%d",
+		stats.OpenFDs,
+		stats.RunningSubprocesses,
+		stats.ZombieSubprocesses,
+		stats.ProcessPoolUsed,
+		stats.ProcessPoolLimit,
+	)
+	if stats.FDSoftLimit > 0 {
+		line += fmt.Sprintf(" fd_soft_limit=%d", stats.FDSoftLimit)
+	}
+	if warning := stats.ExhaustionWarning(); warning != "" {
+		return line + " (" + warning + ")", true, false
+	}
+	return line, false, false
 }
 
 func exportCmd() *cobra.Command {

--- a/cmd/v100/cmd_admin_test.go
+++ b/cmd/v100/cmd_admin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,24 @@ func TestSandboxBackendNeedsDocker(t *testing.T) {
 	cfg.Sandbox.Backend = "docker"
 	if !sandboxBackendNeedsDocker(cfg) {
 		t.Fatal("expected docker backend to require docker")
+	}
+}
+
+func TestExecutorResourceStatusLineReportsResources(t *testing.T) {
+	line, unhealthy, unavailable := executorResourceStatusLine()
+	if runtime.GOOS == "linux" {
+		if unavailable {
+			t.Fatalf("resource status reported unavailable: %q", line)
+		}
+		for _, want := range []string{"Executor resources:", "open_fds=", "subprocesses=", "zombies=", "process_pool=", "fd_soft_limit="} {
+			if !strings.Contains(line, want) {
+				t.Fatalf("resource status line missing %q in %q", want, line)
+			}
+		}
+		return
+	}
+	if unhealthy || !unavailable || !strings.Contains(line, "Executor resources: unavailable") {
+		t.Fatalf("resource status = (%q, unhealthy=%v, unavailable=%v), want unavailable only", line, unhealthy, unavailable)
 	}
 }
 

--- a/internal/core/executor/docker.go
+++ b/internal/core/executor/docker.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -134,7 +133,11 @@ func (s *DockerSession) Run(ctx context.Context, req RunRequest) (Result, error)
 	if req.Stdin != "" {
 		stdin = strings.NewReader(req.Stdin)
 	}
-	return s.runDocker(ctx, stdin, req.StdoutWriter, req.StderrWriter, s.execArgs(req)...)
+	res, err := s.runDocker(ctx, stdin, req.StdoutWriter, req.StderrWriter, s.execArgs(req)...)
+	if ctx.Err() != nil {
+		s.terminateContainerAfterCanceledRun()
+	}
+	return res, err
 }
 
 func (s *DockerSession) Workspace() string { return s.sandboxDir }
@@ -202,38 +205,27 @@ func (s *DockerSession) defaultExecEnv() []string {
 }
 
 func (s *DockerSession) runDocker(ctx context.Context, stdin io.Reader, stdoutWriter, stderrWriter io.Writer, args ...string) (Result, error) {
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	if stdin != nil {
-		cmd.Stdin = stdin
-	}
+	return runProcess(ctx, processRequest{
+		Command:      "docker",
+		Args:         args,
+		Stdin:        stdin,
+		StdoutWriter: stdoutWriter,
+		StderrWriter: stderrWriter,
+	})
+}
 
-	var stdout, stderr bytes.Buffer
-	var stdoutW io.Writer = &stdout
-	var stderrW io.Writer = &stderr
-	if stdoutWriter != nil {
-		stdoutW = io.MultiWriter(stdoutW, stdoutWriter)
+func (s *DockerSession) terminateContainerAfterCanceledRun() {
+	if strings.TrimSpace(s.containerName) == "" {
+		return
 	}
-	if stderrWriter != nil {
-		stderrW = io.MultiWriter(stderrW, stderrWriter)
+	runDockerKill := func(signal string) {
+		ctx, cancel := context.WithTimeout(context.Background(), dockerCommandTimeout)
+		defer cancel()
+		_ = exec.CommandContext(ctx, "docker", "kill", "--signal", signal, s.containerName).Run()
 	}
-	cmd.Stdout = stdoutW
-	cmd.Stderr = stderrW
-
-	err := cmd.Run()
-	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			return Result{}, err
-		}
-	}
-	return Result{
-		ExitCode: exitCode,
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		Err:      err,
-	}, nil
+	runDockerKill("TERM")
+	time.Sleep(processKillGrace)
+	runDockerKill("KILL")
 }
 
 func dockerContainerName(runID string) string {

--- a/internal/core/executor/docker_test.go
+++ b/internal/core/executor/docker_test.go
@@ -1,10 +1,14 @@
 package executor
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tripledoublev/v100/internal/config"
 )
@@ -105,6 +109,173 @@ func TestDockerSessionWritesSeccompProfile(t *testing.T) {
 	}
 }
 
+func TestDockerSessionWriteSeccompRequiresPath(t *testing.T) {
+	session := &DockerSession{}
+	if err := session.writeSeccompProfile(); err == nil {
+		t.Fatal("writeSeccompProfile returned nil, want error")
+	}
+}
+
+func TestDockerSessionIdentityAndContainerName(t *testing.T) {
+	session := &DockerSession{runID: "run-1"}
+	if session.ID() != "run-1" {
+		t.Fatalf("ID() = %q, want run-1", session.ID())
+	}
+	if session.Type() != "docker" {
+		t.Fatalf("Type() = %q, want docker", session.Type())
+	}
+	if got := dockerContainerName("a/b:c d"); got != "v100-a-b-c-d" {
+		t.Fatalf("dockerContainerName() = %q, want v100-a-b-c-d", got)
+	}
+	if got := dockerContainerName(" "); got != "v100-run" {
+		t.Fatalf("dockerContainerName(blank) = %q, want v100-run", got)
+	}
+}
+
+func TestDockerSessionRunUsesProcessRunner(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "docker.log")
+	installFakeDocker(t, fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %s
+cat >/dev/null
+echo docker-stdout
+echo docker-stderr >&2
+exit 7
+`, strconv.Quote(logPath)))
+
+	session := &DockerSession{containerName: "v100-run-1"}
+	res, err := session.Run(context.Background(), RunRequest{
+		Command: "printf",
+		Args:    []string{"ok"},
+		Dir:     "subdir",
+		Env:     []string{"A=B"},
+		Stdin:   "input",
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if res.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7", res.ExitCode)
+	}
+	if res.Err == nil {
+		t.Fatal("Result.Err is nil, want exit error")
+	}
+	if !strings.Contains(res.Stdout, "docker-stdout") || !strings.Contains(res.Stderr, "docker-stderr") {
+		t.Fatalf("unexpected output stdout=%q stderr=%q", res.Stdout, res.Stderr)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"exec -i", "-w /workspace/subdir", "-e A=B", "v100-run-1 printf ok"} {
+		if !strings.Contains(string(logged), want) {
+			t.Fatalf("fake docker log missing %q in:\n%s", want, string(logged))
+		}
+	}
+}
+
+func TestDockerSessionRunKillsContainerOnCancellation(t *testing.T) {
+	restoreGrace := setProcessKillGraceForTest(10 * time.Millisecond)
+	defer restoreGrace()
+
+	logPath := filepath.Join(t.TempDir(), "docker.log")
+	installFakeDocker(t, fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %s
+if [ "$1" = "exec" ]; then
+  sleep 10
+fi
+exit 0
+`, strconv.Quote(logPath)))
+
+	session := &DockerSession{containerName: "v100-run-1"}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	res, err := session.Run(ctx, RunRequest{
+		Command: "sleep",
+		Args:    []string{"10"},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if res.Err == nil || res.ExitCode == 0 {
+		t.Fatalf("Run result = exit %d err %v, want canceled docker exec", res.ExitCode, res.Err)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"exec -w /workspace",
+		"kill --signal TERM v100-run-1",
+		"kill --signal KILL v100-run-1",
+	} {
+		if !strings.Contains(string(logged), want) {
+			t.Fatalf("fake docker log missing %q in:\n%s", want, string(logged))
+		}
+	}
+}
+
+func TestDockerSessionStartAndCloseUseProcessRunner(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "docker.log")
+	installFakeDocker(t, fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %s
+exit 0
+`, strconv.Quote(logPath)))
+
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "marker.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	session := &DockerSession{
+		runID:           "run-1",
+		sourceWorkspace: sourceDir,
+		sandboxDir:      filepath.Join(runDir, "workspace"),
+		containerName:   "v100-run-1",
+		seccompPath:     filepath.Join(runDir, "docker-seccomp.json"),
+		image:           "example/v100:latest",
+		networkMode:     "none",
+	}
+	if err := session.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(session.sandboxDir, "marker.txt")); err != nil {
+		t.Fatalf("workspace missing marker: %v", err)
+	}
+	if _, err := os.Stat(session.seccompPath); err != nil {
+		t.Fatalf("seccomp profile missing: %v", err)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"rm -f v100-run-1", "run -d --rm", "--name v100-run-1"} {
+		if !strings.Contains(string(logged), want) {
+			t.Fatalf("fake docker log missing %q in:\n%s", want, string(logged))
+		}
+	}
+}
+
+func TestDockerSessionStartRequiresImage(t *testing.T) {
+	session := &DockerSession{}
+	if err := session.Start(context.Background()); err == nil {
+		t.Fatal("Start returned nil, want missing image error")
+	}
+}
+
+func TestDockerSessionCloseReportsFailure(t *testing.T) {
+	installFakeDocker(t, `#!/bin/sh
+echo bad >&2
+exit 2
+`)
+	session := &DockerSession{containerName: "v100-run-1"}
+	if err := session.Close(); err == nil || !strings.Contains(err.Error(), "bad") {
+		t.Fatalf("Close error = %v, want docker failure", err)
+	}
+}
+
 func TestFactoryReturnsDockerExecutor(t *testing.T) {
 	execFactory, err := NewExecutor(config.SandboxConfig{
 		Enabled: true,
@@ -147,4 +318,14 @@ func TestNewDockerExecutorNormalizesBaseDirToAbsolute(t *testing.T) {
 	if execFactory.BaseDir != filepath.Join(cwd, "runs") {
 		t.Fatalf("BaseDir = %q, want %q", execFactory.BaseDir, filepath.Join(cwd, "runs"))
 	}
+}
+
+func installFakeDocker(t *testing.T, script string) {
+	t.Helper()
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/core/executor/host.go
+++ b/internal/core/executor/host.go
@@ -1,12 +1,10 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -75,43 +73,20 @@ func (s *HostSession) Run(ctx context.Context, req RunRequest) (Result, error) {
 		fullDir = filepath.Join(baseDir, dir)
 	}
 
-	cmd := exec.CommandContext(ctx, req.Command, req.Args...)
-	cmd.Dir = fullDir
-	cmd.Env = append(os.Environ(), req.Env...)
+	var stdin io.Reader
 	if req.Stdin != "" {
-		cmd.Stdin = strings.NewReader(req.Stdin)
+		stdin = strings.NewReader(req.Stdin)
 	}
 
-	var stdout, stderr bytes.Buffer
-	var stdoutW io.Writer = &stdout
-	var stderrW io.Writer = &stderr
-
-	if req.StdoutWriter != nil {
-		stdoutW = io.MultiWriter(stdoutW, req.StdoutWriter)
-	}
-	if req.StderrWriter != nil {
-		stderrW = io.MultiWriter(stderrW, req.StderrWriter)
-	}
-
-	cmd.Stdout = stdoutW
-	cmd.Stderr = stderrW
-
-	err := cmd.Run()
-	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			return Result{}, err
-		}
-	}
-
-	return Result{
-		ExitCode: exitCode,
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		Err:      err,
-	}, nil
+	return runProcess(ctx, processRequest{
+		Command:      req.Command,
+		Args:         req.Args,
+		Dir:          fullDir,
+		Env:          append(os.Environ(), req.Env...),
+		Stdin:        stdin,
+		StdoutWriter: req.StdoutWriter,
+		StderrWriter: req.StderrWriter,
+	})
 }
 
 func (s *HostSession) Workspace() string {

--- a/internal/core/executor/host_test.go
+++ b/internal/core/executor/host_test.go
@@ -5,7 +5,47 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tripledoublev/v100/internal/config"
 )
+
+func TestHostSessionStartMaterializesWorkspace(t *testing.T) {
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "root.txt"), []byte("root"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sourceDir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "nested", "child.txt"), []byte("child"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := NewHostExecutor(filepath.Join(sourceDir, "runs"))
+	session, err := factory.NewSession("run-1", sourceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ID() != "run-1" {
+		t.Fatalf("ID() = %q, want run-1", session.ID())
+	}
+	if session.Type() != "host" {
+		t.Fatalf("Type() = %q, want host", session.Type())
+	}
+	if err := session.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	workspace := session.Workspace()
+	for _, rel := range []string{"root.txt", filepath.Join("nested", "child.txt")} {
+		if _, err := os.Stat(filepath.Join(workspace, rel)); err != nil {
+			t.Fatalf("workspace missing %s: %v", rel, err)
+		}
+	}
+}
 
 func TestHostSessionRunUsesSourceWorkspaceWhenDisabled(t *testing.T) {
 	sourceDir := t.TempDir()
@@ -33,6 +73,27 @@ func TestHostSessionRunUsesSourceWorkspaceWhenDisabled(t *testing.T) {
 	}
 	if res.Stdout != "ok" {
 		t.Fatalf("expected stdout ok, got %q", res.Stdout)
+	}
+	if got := session.Workspace(); got != sourceDir {
+		t.Fatalf("Workspace() = %q, want %q", got, sourceDir)
+	}
+}
+
+func TestNewExecutorDisabledUsesHostSessionWithoutMaterializing(t *testing.T) {
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "marker.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	factory, err := NewExecutor(config.SandboxConfig{Enabled: false}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := factory.NewSession("run-disabled", sourceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
 	}
 	if got := session.Workspace(); got != sourceDir {
 		t.Fatalf("Workspace() = %q, want %q", got, sourceDir)

--- a/internal/core/executor/process.go
+++ b/internal/core/executor/process.go
@@ -1,0 +1,177 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultMaxConcurrentProcesses = 64
+
+var (
+	processLimiterMu sync.Mutex
+	processLimiter   = make(chan struct{}, defaultMaxConcurrentProcesses)
+
+	processKillGrace = 2 * time.Second
+)
+
+type processRequest struct {
+	Command      string
+	Args         []string
+	Env          []string
+	Dir          string
+	Stdin        io.Reader
+	StdoutWriter io.Writer
+	StderrWriter io.Writer
+}
+
+func processPoolStats() (int, int) {
+	processLimiterMu.Lock()
+	defer processLimiterMu.Unlock()
+	return len(processLimiter), cap(processLimiter)
+}
+
+func runProcess(ctx context.Context, req processRequest) (Result, error) {
+	if strings.TrimSpace(req.Command) == "" {
+		return Result{}, fmt.Errorf("executor: command is required")
+	}
+	release, err := acquireProcessSlot(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	defer release()
+
+	cmd := exec.Command(req.Command, req.Args...)
+	prepareCommand(cmd)
+	cmd.Dir = req.Dir
+	if req.Env != nil {
+		cmd.Env = req.Env
+	}
+	if req.Stdin != nil {
+		cmd.Stdin = req.Stdin
+	}
+	cmd.WaitDelay = processKillGrace
+
+	var stdout, stderr bytes.Buffer
+	var stdoutW io.Writer = &stdout
+	var stderrW io.Writer = &stderr
+	if req.StdoutWriter != nil {
+		stdoutW = io.MultiWriter(stdoutW, req.StdoutWriter)
+	}
+	if req.StderrWriter != nil {
+		stderrW = io.MultiWriter(stderrW, req.StderrWriter)
+	}
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+
+	if err := cmd.Start(); err != nil {
+		return Result{}, err
+	}
+	target := newCommandSignalTarget(cmd)
+
+	waitErr := waitForProcess(ctx, cmd, target)
+	exitCode, resultErr, err := classifyProcessError(waitErr, ctx.Err())
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		Err:      resultErr,
+	}, nil
+}
+
+func acquireProcessSlot(ctx context.Context) (func(), error) {
+	processLimiterMu.Lock()
+	limiter := processLimiter
+	processLimiterMu.Unlock()
+
+	select {
+	case limiter <- struct{}{}:
+		return func() { <-limiter }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func waitForProcess(ctx context.Context, cmd *exec.Cmd, target commandSignalTarget) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if errors.Is(err, exec.ErrWaitDelay) {
+			_ = killCommand(target)
+		}
+		return err
+	case <-ctx.Done():
+		_ = terminateCommand(target)
+		select {
+		case err := <-done:
+			if errors.Is(err, exec.ErrWaitDelay) {
+				_ = killCommand(target)
+			}
+			return err
+		case <-time.After(processKillGrace):
+			_ = killCommand(target)
+			select {
+			case err := <-done:
+				if errors.Is(err, exec.ErrWaitDelay) {
+					_ = killCommand(target)
+				}
+				return err
+			case <-time.After(processKillGrace + time.Second):
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+func classifyProcessError(waitErr error, ctxErr error) (int, error, error) {
+	if waitErr == nil {
+		if ctxErr != nil {
+			return -1, ctxErr, nil
+		}
+		return 0, nil, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return exitErr.ExitCode(), waitErr, nil
+	}
+	if ctxErr != nil {
+		return -1, ctxErr, nil
+	}
+	return 0, nil, waitErr
+}
+
+func setProcessLimitForTest(max int) func() {
+	if max <= 0 {
+		panic("process limit must be positive")
+	}
+	processLimiterMu.Lock()
+	oldLimiter := processLimiter
+	processLimiter = make(chan struct{}, max)
+	processLimiterMu.Unlock()
+
+	return func() {
+		processLimiterMu.Lock()
+		processLimiter = oldLimiter
+		processLimiterMu.Unlock()
+	}
+}
+
+func setProcessKillGraceForTest(d time.Duration) func() {
+	old := processKillGrace
+	processKillGrace = d
+	return func() { processKillGrace = old }
+}

--- a/internal/core/executor/process_exists_windows_test.go
+++ b/internal/core/executor/process_exists_windows_test.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package executor
+
+func processExists(pid int) bool {
+	return false
+}

--- a/internal/core/executor/process_test.go
+++ b/internal/core/executor/process_test.go
@@ -1,0 +1,388 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type processRunOutcome struct {
+	res Result
+	err error
+}
+
+func TestRunProcessSendsSIGTERMBeforeKill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM is not available on windows")
+	}
+	restoreGrace := setProcessKillGraceForTest(500 * time.Millisecond)
+	defer restoreGrace()
+
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	term := filepath.Join(dir, "term")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan processRunOutcome, 1)
+
+	go func() {
+		script := fmt.Sprintf(
+			"trap 'printf term > %s; exit 7' TERM; printf ready > %s; while :; do :; done",
+			strconv.Quote(term),
+			strconv.Quote(ready),
+		)
+		res, err := runProcess(ctx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		done <- processRunOutcome{res: res, err: err}
+	}()
+
+	waitForFile(t, ready, 2*time.Second)
+	cancel()
+
+	outcome := waitForProcessRun(t, done, 2*time.Second)
+	if outcome.err != nil {
+		t.Fatalf("runProcess returned error: %v", outcome.err)
+	}
+	if outcome.res.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7 (stderr=%q)", outcome.res.ExitCode, outcome.res.Stderr)
+	}
+	if outcome.res.Err == nil {
+		t.Fatal("Result.Err is nil, want exit error")
+	}
+	if _, err := os.Stat(term); err != nil {
+		t.Fatalf("SIGTERM trap did not write marker: %v", err)
+	}
+}
+
+func TestRunProcessKillsAfterSIGTERMGrace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM is not available on windows")
+	}
+	restoreGrace := setProcessKillGraceForTest(25 * time.Millisecond)
+	defer restoreGrace()
+
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan processRunOutcome, 1)
+
+	go func() {
+		script := fmt.Sprintf(
+			"trap '' TERM; printf ready > %s; while :; do :; done",
+			strconv.Quote(ready),
+		)
+		res, err := runProcess(ctx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		done <- processRunOutcome{res: res, err: err}
+	}()
+
+	waitForFile(t, ready, 2*time.Second)
+	cancel()
+
+	outcome := waitForProcessRun(t, done, 2*time.Second)
+	if outcome.err != nil {
+		t.Fatalf("runProcess returned error: %v", outcome.err)
+	}
+	if outcome.res.Err == nil {
+		t.Fatal("Result.Err is nil, want forced-kill exit error")
+	}
+	if outcome.res.ExitCode == 0 {
+		t.Fatalf("ExitCode = 0, want non-zero after forced kill")
+	}
+}
+
+func TestRunProcessDrainsStdoutAndStderrOnExit(t *testing.T) {
+	res, err := runProcess(context.Background(), processRequest{
+		Command: "sh",
+		Args: []string{"-c", `
+i=0
+while [ "$i" -lt 1000 ]; do
+  printf 'out-%04d\n' "$i"
+  printf 'err-%04d\n' "$i" >&2
+  i=$((i + 1))
+done
+`},
+	})
+	if err != nil {
+		t.Fatalf("runProcess returned error: %v", err)
+	}
+	if res.ExitCode != 0 || res.Err != nil {
+		t.Fatalf("unexpected result: exit=%d err=%v stderr=%q", res.ExitCode, res.Err, res.Stderr)
+	}
+	if got := strings.Count(res.Stdout, "out-"); got != 1000 {
+		t.Fatalf("stdout line count = %d, want 1000", got)
+	}
+	if got := strings.Count(res.Stderr, "err-"); got != 1000 {
+		t.Fatalf("stderr line count = %d, want 1000", got)
+	}
+}
+
+func TestRunProcessReturnsWhenBackgroundChildKeepsPipeOpen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are not available on windows")
+	}
+	restoreGrace := setProcessKillGraceForTest(25 * time.Millisecond)
+	defer restoreGrace()
+
+	dir := t.TempDir()
+	childPIDPath := filepath.Join(dir, "child.pid")
+	start := time.Now()
+	_, err := runProcess(context.Background(), processRequest{
+		Command: "sh",
+		Args: []string{"-c", fmt.Sprintf(
+			"sleep 10 & printf '%%s' \"$!\" > %s; exit 0",
+			strconv.Quote(childPIDPath),
+		)},
+	})
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("runProcess error = %v, want exec.ErrWaitDelay", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("runProcess took %s, want bounded pipe drain wait", elapsed)
+	}
+
+	pidBytes, err := os.ReadFile(childPIDPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse child pid: %v", err)
+	}
+	waitForProcessExit(t, childPID, 2*time.Second)
+}
+
+func TestProcessPoolLimitsConcurrentRuns(t *testing.T) {
+	restoreLimit := setProcessLimitForTest(1)
+	defer restoreLimit()
+
+	dir := t.TempDir()
+	firstReady := filepath.Join(dir, "first-ready")
+	releaseFirst := filepath.Join(dir, "release-first")
+	secondStarted := filepath.Join(dir, "second-started")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	firstDone := make(chan processRunOutcome, 1)
+	go func() {
+		script := fmt.Sprintf(
+			"printf ready > %s; while [ ! -f %s ]; do sleep 0.05; done",
+			strconv.Quote(firstReady),
+			strconv.Quote(releaseFirst),
+		)
+		res, err := runProcess(ctx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		firstDone <- processRunOutcome{res: res, err: err}
+	}()
+	waitForFile(t, firstReady, 2*time.Second)
+
+	secondDone := make(chan processRunOutcome, 1)
+	go func() {
+		script := fmt.Sprintf("printf started > %s", strconv.Quote(secondStarted))
+		res, err := runProcess(ctx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		secondDone <- processRunOutcome{res: res, err: err}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(secondStarted); err == nil {
+		t.Fatal("second process started while first process held the only slot")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat second marker: %v", err)
+	}
+
+	if err := os.WriteFile(releaseFirst, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first := waitForProcessRun(t, firstDone, 2*time.Second)
+	second := waitForProcessRun(t, secondDone, 2*time.Second)
+	for name, outcome := range map[string]processRunOutcome{"first": first, "second": second} {
+		if outcome.err != nil {
+			t.Fatalf("%s runProcess returned error: %v", name, outcome.err)
+		}
+		if outcome.res.ExitCode != 0 {
+			t.Fatalf("%s ExitCode = %d, want 0", name, outcome.res.ExitCode)
+		}
+	}
+}
+
+func TestProcessPoolAcquireHonorsContext(t *testing.T) {
+	restoreLimit := setProcessLimitForTest(1)
+	defer restoreLimit()
+
+	dir := t.TempDir()
+	firstReady := filepath.Join(dir, "first-ready")
+	releaseFirst := filepath.Join(dir, "release-first")
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer firstCancel()
+	firstDone := make(chan processRunOutcome, 1)
+	go func() {
+		script := fmt.Sprintf(
+			"printf ready > %s; while [ ! -f %s ]; do sleep 0.05; done",
+			strconv.Quote(firstReady),
+			strconv.Quote(releaseFirst),
+		)
+		res, err := runProcess(firstCtx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		firstDone <- processRunOutcome{res: res, err: err}
+	}()
+	waitForFile(t, firstReady, 2*time.Second)
+
+	blockedCtx, blockedCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer blockedCancel()
+	_, err := runProcess(blockedCtx, processRequest{Command: "true"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runProcess error = %v, want context deadline exceeded", err)
+	}
+
+	if err := os.WriteFile(releaseFirst, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	waitForProcessRun(t, firstDone, 2*time.Second)
+}
+
+func TestCurrentResourceStatsReportsFDLimit(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resource stats use /proc on linux")
+	}
+	stats, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+	if stats.OpenFDs <= 0 {
+		t.Fatalf("OpenFDs = %d, want positive", stats.OpenFDs)
+	}
+	if stats.FDSoftLimit <= 0 {
+		t.Fatalf("FDSoftLimit = %d, want positive", stats.FDSoftLimit)
+	}
+	if stats.ProcessPoolLimit <= 0 {
+		t.Fatalf("ProcessPoolLimit = %d, want positive", stats.ProcessPoolLimit)
+	}
+}
+
+func TestCurrentResourceStatsCountsRunningSubprocess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resource stats use /proc on linux")
+	}
+	before, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+
+	cmd := exec.Command("sh", "-c", "sleep 2")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats, err := CurrentResourceStats()
+		if err == nil && stats.RunningSubprocesses >= before.RunningSubprocesses+1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stats, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+	t.Fatalf("RunningSubprocesses = %d, want at least %d", stats.RunningSubprocesses, before.RunningSubprocesses+1)
+}
+
+func TestCurrentResourceStatsReportsProcessPoolExhaustion(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resource stats use /proc on linux")
+	}
+	restoreLimit := setProcessLimitForTest(1)
+	defer restoreLimit()
+	release, err := acquireProcessSlot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	stats, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+	if stats.ProcessPoolUsed != 1 || stats.ProcessPoolLimit != 1 {
+		t.Fatalf("process pool stats = %d/%d, want 1/1", stats.ProcessPoolUsed, stats.ProcessPoolLimit)
+	}
+	if warning := stats.ExhaustionWarning(); !strings.Contains(warning, "process pool exhausted") {
+		t.Fatalf("ExhaustionWarning() = %q, want process pool exhausted", warning)
+	}
+}
+
+func TestRunProcessStressNoZombieOrFDLeak(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resource leak assertions use /proc on linux")
+	}
+	before, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		res, err := runProcess(context.Background(), processRequest{Command: "true"})
+		if err != nil {
+			t.Fatalf("run %d returned error: %v", i, err)
+		}
+		if res.ExitCode != 0 || res.Err != nil {
+			t.Fatalf("run %d unexpected result: exit=%d err=%v", i, res.ExitCode, res.Err)
+		}
+	}
+
+	after, err := CurrentResourceStats()
+	if err != nil {
+		t.Fatalf("CurrentResourceStats returned error: %v", err)
+	}
+	if after.ZombieSubprocesses > before.ZombieSubprocesses {
+		t.Fatalf("zombies grew from %d to %d", before.ZombieSubprocesses, after.ZombieSubprocesses)
+	}
+	if delta := after.OpenFDs - before.OpenFDs; delta > 4 {
+		t.Fatalf("open FDs grew by %d (%d to %d)", delta, before.OpenFDs, after.OpenFDs)
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func waitForProcessRun(t *testing.T, done <-chan processRunOutcome, timeout time.Duration) processRunOutcome {
+	t.Helper()
+	select {
+	case outcome := <-done:
+		return outcome
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for process run")
+		return processRunOutcome{}
+	}
+}
+
+func waitForProcessExit(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processExists(pid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process %d still exists", pid)
+}

--- a/internal/core/executor/process_unix_test.go
+++ b/internal/core/executor/process_unix_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunProcessTerminatesChildProcessGroup(t *testing.T) {
+	restoreGrace := setProcessKillGraceForTest(100 * time.Millisecond)
+	defer restoreGrace()
+
+	dir := t.TempDir()
+	childPIDPath := filepath.Join(dir, "child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan processRunOutcome, 1)
+
+	go func() {
+		script := fmt.Sprintf(
+			"sleep 10 & printf '%%s' \"$!\" > %s; wait",
+			strconv.Quote(childPIDPath),
+		)
+		res, err := runProcess(ctx, processRequest{Command: "sh", Args: []string{"-c", script}})
+		done <- processRunOutcome{res: res, err: err}
+	}()
+
+	waitForFile(t, childPIDPath, 2*time.Second)
+	pidBytes, err := os.ReadFile(childPIDPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse child pid: %v", err)
+	}
+	if !processExists(childPID) {
+		t.Fatalf("child process %d was not running before cancellation", childPID)
+	}
+
+	cancel()
+	outcome := waitForProcessRun(t, done, 2*time.Second)
+	if outcome.err != nil {
+		t.Fatalf("runProcess returned error: %v", outcome.err)
+	}
+	if outcome.res.Err == nil {
+		t.Fatal("Result.Err is nil, want signal exit error")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processExists(childPID) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child process %d still exists after parent cancellation", childPID)
+}
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || !errors.Is(err, syscall.ESRCH)
+}

--- a/internal/core/executor/resource_linux.go
+++ b/internal/core/executor/resource_linux.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package executor
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ResourceStats describes executor-relevant process resources for the current v100 process.
+type ResourceStats struct {
+	OpenFDs             int
+	FDSoftLimit         uint64
+	RunningSubprocesses int
+	ZombieSubprocesses  int
+	ProcessPoolUsed     int
+	ProcessPoolLimit    int
+}
+
+// CurrentResourceStats reports open file descriptors and direct child process state.
+func CurrentResourceStats() (ResourceStats, error) {
+	fds, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return ResourceStats{}, fmt.Errorf("read /proc/self/fd: %w", err)
+	}
+	running, zombies, err := countDirectChildren(os.Getpid())
+	if err != nil {
+		return ResourceStats{}, err
+	}
+
+	poolUsed, poolLimit := processPoolStats()
+	stats := ResourceStats{
+		OpenFDs:             len(fds),
+		RunningSubprocesses: running,
+		ZombieSubprocesses:  zombies,
+		ProcessPoolUsed:     poolUsed,
+		ProcessPoolLimit:    poolLimit,
+	}
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err == nil {
+		stats.FDSoftLimit = limit.Cur
+	}
+	return stats, nil
+}
+
+func (s ResourceStats) ExhaustionWarning() string {
+	switch {
+	case s.ZombieSubprocesses > 0:
+		return fmt.Sprintf("%d zombie subprocess(es)", s.ZombieSubprocesses)
+	case s.ProcessPoolLimit > 0 && s.ProcessPoolUsed >= s.ProcessPoolLimit:
+		return fmt.Sprintf("executor process pool exhausted (%d/%d)", s.ProcessPoolUsed, s.ProcessPoolLimit)
+	case s.FDSoftLimit > 0 && uint64(s.OpenFDs)*100 >= s.FDSoftLimit*80:
+		return fmt.Sprintf("open file descriptors near soft limit (%d/%d)", s.OpenFDs, s.FDSoftLimit)
+	default:
+		return ""
+	}
+}
+
+func countDirectChildren(parentPID int) (int, int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, 0, fmt.Errorf("read /proc: %w", err)
+	}
+
+	running := 0
+	zombies := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		state, ppid, err := readProcStat(entry.Name())
+		if err != nil {
+			continue
+		}
+		if ppid != parentPID {
+			continue
+		}
+		if state == "Z" {
+			zombies++
+		} else {
+			running++
+		}
+	}
+	return running, zombies, nil
+}
+
+func readProcStat(pid string) (string, int, error) {
+	b, err := os.ReadFile("/proc/" + pid + "/stat")
+	if err != nil {
+		return "", 0, err
+	}
+	stat := string(b)
+	endComm := strings.LastIndex(stat, ")")
+	if endComm == -1 || endComm+2 >= len(stat) {
+		return "", 0, fmt.Errorf("malformed stat for pid %s", pid)
+	}
+	fields := strings.Fields(stat[endComm+2:])
+	if len(fields) < 2 {
+		return "", 0, fmt.Errorf("malformed stat fields for pid %s", pid)
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return "", 0, err
+	}
+	return fields[0], ppid, nil
+}

--- a/internal/core/executor/resource_other.go
+++ b/internal/core/executor/resource_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package executor
+
+import "fmt"
+
+// ResourceStats describes executor-relevant process resources for the current v100 process.
+type ResourceStats struct {
+	OpenFDs             int
+	FDSoftLimit         uint64
+	RunningSubprocesses int
+	ZombieSubprocesses  int
+	ProcessPoolUsed     int
+	ProcessPoolLimit    int
+}
+
+// CurrentResourceStats reports resource stats when the platform exposes the needed data.
+func CurrentResourceStats() (ResourceStats, error) {
+	return ResourceStats{}, fmt.Errorf("executor resource stats are unsupported on this platform")
+}
+
+func (s ResourceStats) ExhaustionWarning() string {
+	return ""
+}

--- a/internal/core/executor/signal_unix.go
+++ b/internal/core/executor/signal_unix.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package executor
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+type commandSignalTarget struct {
+	cmd      *exec.Cmd
+	pgid     int
+	hasPGID  bool
+	fallback bool
+}
+
+func prepareCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func newCommandSignalTarget(cmd *exec.Cmd) commandSignalTarget {
+	target := commandSignalTarget{cmd: cmd}
+	if cmd.Process == nil {
+		return target
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err == nil {
+		target.pgid = pgid
+		target.hasPGID = true
+	}
+	target.fallback = true
+	return target
+}
+
+func terminateCommand(target commandSignalTarget) error {
+	return signalCommandGroup(target, syscall.SIGTERM)
+}
+
+func killCommand(target commandSignalTarget) error {
+	return signalCommandGroup(target, syscall.SIGKILL)
+}
+
+func signalCommandGroup(target commandSignalTarget, signal syscall.Signal) error {
+	if target.hasPGID {
+		if err := syscall.Kill(-target.pgid, signal); err == nil {
+			return nil
+		}
+	}
+	if target.fallback && target.cmd.Process != nil {
+		return target.cmd.Process.Signal(signal)
+	}
+	return nil
+}

--- a/internal/core/executor/signal_windows.go
+++ b/internal/core/executor/signal_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package executor
+
+import "os/exec"
+
+type commandSignalTarget struct {
+	cmd *exec.Cmd
+}
+
+func prepareCommand(cmd *exec.Cmd) {}
+
+func newCommandSignalTarget(cmd *exec.Cmd) commandSignalTarget {
+	return commandSignalTarget{cmd: cmd}
+}
+
+func terminateCommand(target commandSignalTarget) error {
+	return killCommand(target)
+}
+
+func killCommand(target commandSignalTarget) error {
+	if target.cmd.Process == nil {
+		return nil
+	}
+	return target.cmd.Process.Kill()
+}


### PR DESCRIPTION
Closes #219

## Summary
- routes host and Docker command execution through one bounded process runner
- sends SIGTERM then SIGKILL to the Unix process group on cancellation while preserving stdout/stderr draining through Wait
- adds Linux executor resource stats to `v100 doctor` for open FDs, child processes, and zombies
- adds signal, pipe-drain, FD/zombie leak, process-pool, and 1000-run stress coverage
- adds a targeted executor hardening CI workflow for the leak stress test

## Review follow-up
- stores the Unix process group immediately after process start so cleanup still targets descendants after the direct child exits
- bounds inherited-pipe hangs with `exec.Cmd.WaitDelay` and a post-KILL timeout
- kills the Docker container on canceled `docker exec` runs so container-side tool processes cannot outlive the canceled run
- reports executor process-pool occupancy in `v100 doctor`

## Verification
- `make lint`
- `./scripts/test.sh`
- `env GOCACHE=/tmp/v100-issue219-gocache go test -race -cover ./internal/core/executor -count=1` (83.6% executor coverage)
- `env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue219 GIT_WORK_TREE=/tmp/v100-issue219 GOCACHE=/tmp/v100-issue219-gocache go build ./...`

Note: plain `go build ./...` in the isolated `/tmp` worktree failed only at Go VCS stamping because the sandboxed Go process could not discover the linked `.git` worktree. The final build keeps VCS stamping enabled by passing the explicit Git worktree metadata.
