### PR TITLE
feat: add delta workspace snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ Use standard Go formatting: run `gofmt`/`go test` before submitting changes. Kee
 
 Place Go tests beside the package they cover using `*_test.go`. Use focused table tests for command flags, solver behavior, tool handling, and policy edge cases. Run `make test` for normal validation; use targeted runs such as `go test ./internal/core -run TestName` while iterating. Keep benchmark scenarios in TOML files under `benchmarks/`, `tests/benchmarks/`, or `dogfood/`.
 
+## Workspace Snapshots
+
+Workspace snapshots default to delta mode. Each snapshot stores a manifest plus content-addressed blobs under the run's `snapshots/content/` directory; unchanged files reuse prior digests and identical file contents are stored once. Full-copy mode remains available through `WorkspaceSnapshotOptions{Mode: SnapshotModeFullCopy}` for comparison and compatibility testing.
+
+Delta restore rebuilds the workspace from the manifest and blob store, so tests should verify restored workspace state instead of assuming every snapshot directory is a full materialized tree. `CaptureAsync` is available for non-preimage backups where callers can wait on the returned `Done` channel before restore; normal pre-mutation snapshots remain synchronous so the captured state is stable before a mutating tool runs.
+
 ## Commit & Pull Request Guidelines
 
 Recent history uses short imperative summaries, often with `feat:` or `fix:` prefixes, for example `fix: enable tool execution in synthesis tasks`. Keep commits narrowly scoped and mention affected subsystems when useful. Pull requests should include a concise description, the commands run, linked issues when applicable, and screenshots or terminal output for TUI-facing changes. Call out configuration, provider, network, or sandbox behavior changes explicitly.

--- a/cmd/v100/cmd_admin.go
+++ b/cmd/v100/cmd_admin.go
@@ -695,6 +695,12 @@ func exportCmd() *cobra.Command {
 					return fmt.Errorf("add snapshot: %w", err)
 				}
 			}
+			snapshotDir := filepath.Join(runDir, "snapshots")
+			if _, err := os.Stat(snapshotDir); err == nil {
+				if err := addPathToTar(tw, snapshotDir, "snapshots"); err != nil {
+					return fmt.Errorf("add snapshots: %w", err)
+				}
+			}
 
 			fmt.Printf("Run %s exported to: %s\n", ui.Info(runID), ui.OK(exportPath))
 			return nil
@@ -726,6 +732,54 @@ func addFileToTar(tw *tar.Writer, srcPath, tarPath string) error {
 
 	_, err = io.Copy(tw, f)
 	return err
+}
+
+func addPathToTar(tw *tar.Writer, srcPath, tarPath string) error {
+	return filepath.WalkDir(srcPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcPath, path)
+		if err != nil {
+			return err
+		}
+		name := tarPath
+		if rel != "." {
+			name = filepath.ToSlash(filepath.Join(tarPath, rel))
+		}
+		link := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+		header, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return err
+		}
+		header.Name = name
+		if d.IsDir() && !strings.HasSuffix(header.Name, "/") {
+			header.Name += "/"
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		_, err = io.Copy(tw, f)
+		return err
+	})
 }
 
 func sandboxBackendNeedsDocker(cfg *config.Config) bool {

--- a/cmd/v100/cmd_admin_test.go
+++ b/cmd/v100/cmd_admin_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -38,6 +41,46 @@ func TestExecutorResourceStatusLineReportsResources(t *testing.T) {
 	}
 	if unhealthy || !unavailable || !strings.Contains(line, "Executor resources: unavailable") {
 		t.Fatalf("resource status = (%q, unhealthy=%v, unavailable=%v), want unavailable only", line, unhealthy, unavailable)
+	}
+}
+
+func TestAddPathToTarIncludesSnapshotTree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "snap-1", "content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "snap-1", ".v100snapshot.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "snap-1", "content", "blob"), []byte("data"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := addPathToTar(tw, root, "snapshots"); err != nil {
+		t.Fatalf("addPathToTar returned error: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]bool{}
+	tr := tar.NewReader(&buf)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[header.Name] = true
+	}
+	for _, want := range []string{"snapshots/", "snapshots/snap-1/", "snapshots/snap-1/.v100snapshot.json", "snapshots/snap-1/content/blob"} {
+		if !seen[want] {
+			t.Fatalf("tar missing %q; seen=%v", want, seen)
+		}
 	}
 }
 

--- a/cmd/v100/cmd_graph.go
+++ b/cmd/v100/cmd_graph.go
@@ -70,6 +70,22 @@ type dagEdge struct {
 	Kind string `json:"kind"`
 }
 
+type graphSnapshotManifest struct {
+	Version int `json:"version"`
+	Dirs    []struct {
+		Path string `json:"path"`
+	} `json:"dirs,omitempty"`
+	Files []struct {
+		Path string `json:"path"`
+		Size int64  `json:"size"`
+	} `json:"files,omitempty"`
+	Links []struct {
+		Path   string `json:"path"`
+		Target string `json:"target"`
+	} `json:"links,omitempty"`
+	Method string `json:"method"`
+}
+
 func renderTraceDAGHTML(runID, runDir string, events []core.Event) (string, error) {
 	nodes, edges := buildTraceDAG(runDir, events)
 	payload, err := json.Marshal(struct {
@@ -157,6 +173,14 @@ func snapshotTreeSummary(runDir, snapshotID string) string {
 		return "No sandbox snapshot is associated with this point in the trace."
 	}
 	root := filepath.Join(runDir, "snapshots", snapshotID)
+	if entries, ok, err := collectDeltaSnapshotEntries(root, 250); err != nil {
+		return fmt.Sprintf("Snapshot %s is not available on disk: %v", snapshotID, err)
+	} else if ok {
+		if len(entries) == 0 {
+			return fmt.Sprintf("Snapshot %s is empty.", snapshotID)
+		}
+		return fmt.Sprintf("snapshot=%s\n%s", snapshotID, strings.Join(entries, "\n"))
+	}
 	entries, err := collectSnapshotEntries(root, 250)
 	if err != nil {
 		return fmt.Sprintf("Snapshot %s is not available on disk: %v", snapshotID, err)
@@ -165,6 +189,41 @@ func snapshotTreeSummary(runDir, snapshotID string) string {
 		return fmt.Sprintf("Snapshot %s is empty.", snapshotID)
 	}
 	return fmt.Sprintf("snapshot=%s\n%s", snapshotID, strings.Join(entries, "\n"))
+}
+
+func collectDeltaSnapshotEntries(root string, limit int) ([]string, bool, error) {
+	b, err := os.ReadFile(filepath.Join(root, ".v100snapshot.json"))
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	var manifest graphSnapshotManifest
+	if err := json.Unmarshal(b, &manifest); err != nil || manifest.Version == 0 || manifest.Method != string(core.SnapshotModeDelta) {
+		return nil, false, nil
+	}
+	entries := make([]string, 0, len(manifest.Dirs)+len(manifest.Files)+len(manifest.Links))
+	for _, dir := range manifest.Dirs {
+		if len(entries) >= limit {
+			break
+		}
+		entries = append(entries, strings.TrimSuffix(dir.Path, "/")+"/")
+	}
+	for _, link := range manifest.Links {
+		if len(entries) >= limit {
+			break
+		}
+		entries = append(entries, fmt.Sprintf("%s -> %s", link.Path, link.Target))
+	}
+	for _, file := range manifest.Files {
+		if len(entries) >= limit {
+			break
+		}
+		entries = append(entries, fmt.Sprintf("%s  %d bytes", file.Path, file.Size))
+	}
+	sort.Strings(entries)
+	return entries, true, nil
 }
 
 func collectSnapshotEntries(root string, limit int) ([]string, error) {

--- a/cmd/v100/cmd_graph_test.go
+++ b/cmd/v100/cmd_graph_test.go
@@ -61,6 +61,35 @@ func TestBuildTraceDAGMarksSnapshotAndRestore(t *testing.T) {
 	}
 }
 
+func TestSnapshotTreeSummaryReadsDeltaManifest(t *testing.T) {
+	runDir := t.TempDir()
+	snapshotDir := filepath.Join(runDir, "snapshots", "snap-1")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]any{
+		"version": 1,
+		"method":  string(core.SnapshotModeDelta),
+		"dirs":    []map[string]any{{"path": "dir"}},
+		"links":   []map[string]any{{"path": "link.txt", "target": "target.txt"}},
+		"files":   []map[string]any{{"path": "dir/state.txt", "size": 5}},
+	}
+	b, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshotDir, ".v100snapshot.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary := snapshotTreeSummary(runDir, "snap-1")
+	for _, want := range []string{"dir/", "link.txt -> target.txt", "dir/state.txt  5 bytes"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q in:\n%s", want, summary)
+		}
+	}
+}
+
 func TestRenderTraceDAGHTMLContainsInteractivePanel(t *testing.T) {
 	doc, err := renderTraceDAGHTML("run-1", t.TempDir(), []core.Event{
 		graphEvent(t, core.EventRunStart, "s1", "e1", core.RunStartPayload{Provider: "test"}),

--- a/internal/core/checkpoint_snapshot_test.go
+++ b/internal/core/checkpoint_snapshot_test.go
@@ -98,10 +98,11 @@ func TestCheckpointSnapshotSkipsCacheDirectories(t *testing.T) {
 	defer func() { _ = trace.Close() }()
 
 	snapshotRoot := filepath.Join(filepath.Dir(workspace), "snapshots")
+	snapshots := core.NewWorkspaceSnapshotManager(workspace, snapshotRoot)
 	loop := &core.Loop{
 		Run:       &core.Run{ID: "cp-run", Dir: workspace, TraceFile: tracePath},
 		Trace:     trace,
-		Snapshots: core.NewWorkspaceSnapshotManager(workspace, snapshotRoot),
+		Snapshots: snapshots,
 	}
 
 	cp, err := loop.CheckpointWithContext(context.Background())
@@ -109,12 +110,20 @@ func TestCheckpointSnapshotSkipsCacheDirectories(t *testing.T) {
 		t.Fatalf("CheckpointWithContext returned error: %v", err)
 	}
 
-	snapPath := filepath.Join(snapshotRoot, cp.SnapshotID)
-	if _, err := os.Stat(filepath.Join(snapPath, ".cache")); !os.IsNotExist(err) {
-		t.Fatalf("expected .cache to be excluded from snapshot, stat err=%v", err)
+	if err := os.RemoveAll(filepath.Join(workspace, ".cache")); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(snapPath, "state.txt")); err != nil {
-		t.Fatalf("expected state.txt in snapshot: %v", err)
+	if err := os.Remove(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshots.Restore(context.Background(), core.RestoreRequest{SnapshotID: cp.SnapshotID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected .cache to be excluded from restored snapshot, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatalf("expected state.txt after restore: %v", err)
 	}
 }
 
@@ -140,10 +149,11 @@ func TestCheckpointSnapshotSkipsGoTelemetry(t *testing.T) {
 	defer func() { _ = trace.Close() }()
 
 	snapshotRoot := filepath.Join(filepath.Dir(workspace), "snapshots")
+	snapshots := core.NewWorkspaceSnapshotManager(workspace, snapshotRoot)
 	loop := &core.Loop{
 		Run:       &core.Run{ID: "cp-run-tel", Dir: workspace, TraceFile: tracePath},
 		Trace:     trace,
-		Snapshots: core.NewWorkspaceSnapshotManager(workspace, snapshotRoot),
+		Snapshots: snapshots,
 	}
 
 	cp, err := loop.CheckpointWithContext(context.Background())
@@ -151,12 +161,20 @@ func TestCheckpointSnapshotSkipsGoTelemetry(t *testing.T) {
 		t.Fatalf("CheckpointWithContext returned error: %v", err)
 	}
 
-	snapPath := filepath.Join(snapshotRoot, cp.SnapshotID)
-	if _, err := os.Stat(filepath.Join(snapPath, ".config", "go", "telemetry")); !os.IsNotExist(err) {
-		t.Fatalf("expected .config/go/telemetry to be excluded from snapshot, stat err=%v", err)
+	if err := os.RemoveAll(filepath.Join(workspace, ".config")); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(snapPath, "state.txt")); err != nil {
-		t.Fatalf("expected state.txt in snapshot: %v", err)
+	if err := os.Remove(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshots.Restore(context.Background(), core.RestoreRequest{SnapshotID: cp.SnapshotID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".config", "go", "telemetry")); !os.IsNotExist(err) {
+		t.Fatalf("expected .config/go/telemetry to be excluded from restored snapshot, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatalf("expected state.txt after restore: %v", err)
 	}
 }
 
@@ -184,10 +202,11 @@ func TestCheckpointSnapshotHonorsV100Ignore(t *testing.T) {
 	defer func() { _ = trace.Close() }()
 
 	snapshotRoot := filepath.Join(filepath.Dir(workspace), "snapshots")
+	snapshots := core.NewWorkspaceSnapshotManager(workspace, snapshotRoot)
 	loop := &core.Loop{
 		Run:       &core.Run{ID: "cp-run-ignore", Dir: workspace, TraceFile: tracePath},
 		Trace:     trace,
-		Snapshots: core.NewWorkspaceSnapshotManager(workspace, snapshotRoot),
+		Snapshots: snapshots,
 	}
 
 	cp, err := loop.CheckpointWithContext(context.Background())
@@ -195,12 +214,20 @@ func TestCheckpointSnapshotHonorsV100Ignore(t *testing.T) {
 		t.Fatalf("CheckpointWithContext returned error: %v", err)
 	}
 
-	snapPath := filepath.Join(snapshotRoot, cp.SnapshotID)
-	if _, err := os.Stat(filepath.Join(snapPath, "tmp")); !os.IsNotExist(err) {
-		t.Fatalf("expected tmp to be excluded from snapshot by .v100ignore, stat err=%v", err)
+	if err := os.RemoveAll(filepath.Join(workspace, "tmp")); err != nil {
+		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(snapPath, "state.txt")); err != nil {
-		t.Fatalf("expected state.txt in snapshot: %v", err)
+	if err := os.Remove(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshots.Restore(context.Background(), core.RestoreRequest{SnapshotID: cp.SnapshotID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "tmp")); !os.IsNotExist(err) {
+		t.Fatalf("expected tmp to be excluded from restored snapshot by .v100ignore, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "state.txt")); err != nil {
+		t.Fatalf("expected state.txt after restore: %v", err)
 	}
 }
 

--- a/internal/core/snapshot.go
+++ b/internal/core/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 )
 
@@ -56,6 +57,13 @@ func (NoopSnapshotManager) Capture(_ context.Context, req SnapshotRequest) (Snap
 	return SnapshotResult{ID: id, Method: "noop"}, nil
 }
 
+func (NoopSnapshotManager) CaptureAsync(_ context.Context, req SnapshotRequest) (AsyncSnapshot, error) {
+	result, err := NoopSnapshotManager{}.Capture(context.Background(), req)
+	done := make(chan error)
+	close(done)
+	return AsyncSnapshot{Result: result, Done: done}, err
+}
+
 func (NoopSnapshotManager) Restore(_ context.Context, req RestoreRequest) (RestoreResult, error) {
 	id := req.SnapshotID
 	if id == "" {
@@ -64,29 +72,118 @@ func (NoopSnapshotManager) Restore(_ context.Context, req RestoreRequest) (Resto
 	return RestoreResult{SnapshotID: id, Method: "noop"}, nil
 }
 
-// WorkspaceSnapshotManager stores full-copy snapshots of a workspace tree.
+// SnapshotMode selects how WorkspaceSnapshotManager persists workspace state.
+type SnapshotMode string
+
+const (
+	SnapshotModeDelta    SnapshotMode = "delta"
+	SnapshotModeFullCopy SnapshotMode = "full_copy"
+)
+
+// WorkspaceSnapshotOptions controls snapshot storage behavior.
+type WorkspaceSnapshotOptions struct {
+	Mode SnapshotMode
+}
+
+// AsyncSnapshot captures the result handle and completion channel for a background snapshot.
+type AsyncSnapshot struct {
+	Result SnapshotResult
+	Done   <-chan error
+}
+
+// WorkspaceSnapshotManager stores restorable snapshots of a workspace tree.
 type WorkspaceSnapshotManager struct {
 	WorkspaceDir string
 	SnapshotRoot string
+	Options      WorkspaceSnapshotOptions
+	mu           sync.Mutex
+	pendingMu    sync.Mutex
+	pending      map[string]<-chan error
+	lastManifest *snapshotManifest
 	seq          uint64
 }
 
 func NewWorkspaceSnapshotManager(workspaceDir, snapshotRoot string) *WorkspaceSnapshotManager {
+	return NewWorkspaceSnapshotManagerWithOptions(workspaceDir, snapshotRoot, WorkspaceSnapshotOptions{
+		Mode: SnapshotModeDelta,
+	})
+}
+
+func NewWorkspaceSnapshotManagerWithOptions(workspaceDir, snapshotRoot string, opts WorkspaceSnapshotOptions) *WorkspaceSnapshotManager {
+	if opts.Mode == "" {
+		opts.Mode = SnapshotModeDelta
+	}
 	return &WorkspaceSnapshotManager{
 		WorkspaceDir: filepath.Clean(workspaceDir),
 		SnapshotRoot: filepath.Clean(snapshotRoot),
+		Options:      opts,
 	}
 }
 
-func (m *WorkspaceSnapshotManager) Capture(_ context.Context, req SnapshotRequest) (SnapshotResult, error) {
-	if strings.TrimSpace(m.WorkspaceDir) == "" || strings.TrimSpace(m.SnapshotRoot) == "" {
-		return SnapshotResult{}, fmt.Errorf("workspace snapshot: workspace and snapshot root are required")
+func (m *WorkspaceSnapshotManager) Capture(ctx context.Context, req SnapshotRequest) (SnapshotResult, error) {
+	id := m.nextSnapshotID(req)
+	return m.captureWithID(ctx, req, id)
+}
+
+// CaptureAsync starts a snapshot in the background. It is intended for non-preimage
+// backups where callers can tolerate waiting on Done before restore.
+func (m *WorkspaceSnapshotManager) CaptureAsync(ctx context.Context, req SnapshotRequest) (AsyncSnapshot, error) {
+	if err := m.validate(); err != nil {
+		return AsyncSnapshot{}, err
+	}
+	id := m.nextSnapshotID(req)
+	done := make(chan error, 1)
+	m.registerPendingSnapshot(id, done)
+	go func() {
+		_, err := m.captureWithID(ctx, req, id)
+		done <- err
+		close(done)
+		m.clearPendingSnapshot(id, done)
+	}()
+	return AsyncSnapshot{
+		Result: SnapshotResult{ID: id, Method: string(m.snapshotMode()) + "_async"},
+		Done:   done,
+	}, nil
+}
+
+func (m *WorkspaceSnapshotManager) captureWithID(ctx context.Context, req SnapshotRequest, id string) (SnapshotResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.validate(); err != nil {
+		return SnapshotResult{}, err
+	}
+	if ctx.Err() != nil {
+		return SnapshotResult{}, ctx.Err()
 	}
 	if err := os.MkdirAll(m.SnapshotRoot, 0o755); err != nil {
 		return SnapshotResult{}, fmt.Errorf("workspace snapshot: mkdir root: %w", err)
 	}
+	if m.snapshotMode() == SnapshotModeFullCopy {
+		return m.captureFullCopy(ctx, id)
+	}
+	return m.captureDelta(ctx, id)
+}
 
-	id := m.nextSnapshotID(req)
+func (m *WorkspaceSnapshotManager) validate() error {
+	if strings.TrimSpace(m.WorkspaceDir) == "" || strings.TrimSpace(m.SnapshotRoot) == "" {
+		return fmt.Errorf("workspace snapshot: workspace and snapshot root are required")
+	}
+	return nil
+}
+
+func (m *WorkspaceSnapshotManager) snapshotMode() SnapshotMode {
+	switch m.Options.Mode {
+	case SnapshotModeFullCopy:
+		return SnapshotModeFullCopy
+	default:
+		return SnapshotModeDelta
+	}
+}
+
+func (m *WorkspaceSnapshotManager) captureFullCopy(ctx context.Context, id string) (SnapshotResult, error) {
+	if ctx.Err() != nil {
+		return SnapshotResult{}, ctx.Err()
+	}
 	dst := filepath.Join(m.SnapshotRoot, id)
 	if err := os.RemoveAll(dst); err != nil {
 		return SnapshotResult{}, fmt.Errorf("workspace snapshot: clear %s: %w", dst, err)
@@ -100,13 +197,28 @@ func (m *WorkspaceSnapshotManager) Capture(_ context.Context, req SnapshotReques
 	return SnapshotResult{ID: id, Method: "full_copy"}, nil
 }
 
-func (m *WorkspaceSnapshotManager) Restore(_ context.Context, req RestoreRequest) (RestoreResult, error) {
+func (m *WorkspaceSnapshotManager) Restore(ctx context.Context, req RestoreRequest) (RestoreResult, error) {
 	if strings.TrimSpace(req.SnapshotID) == "" {
 		return RestoreResult{}, fmt.Errorf("workspace snapshot restore: snapshot id is required")
 	}
+	if err := m.waitPendingSnapshot(ctx, req.SnapshotID); err != nil {
+		return RestoreResult{}, fmt.Errorf("workspace snapshot restore: wait for pending snapshot %s: %w", req.SnapshotID, err)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	src := filepath.Join(m.SnapshotRoot, req.SnapshotID)
 	if _, err := os.Stat(src); err != nil {
 		return RestoreResult{}, fmt.Errorf("workspace snapshot restore: stat %s: %w", src, err)
+	}
+	if isDeltaSnapshotDir(src) {
+		manifest, err := readSnapshotManifest(src)
+		if err != nil {
+			return RestoreResult{}, fmt.Errorf("workspace snapshot restore: read manifest %s: %w", req.SnapshotID, err)
+		}
+		if err := m.restoreDelta(ctx, manifest); err != nil {
+			return RestoreResult{}, fmt.Errorf("workspace snapshot restore: restore %s: %w", req.SnapshotID, err)
+		}
+		return RestoreResult{SnapshotID: req.SnapshotID, Method: manifest.Method}, nil
 	}
 	if err := os.MkdirAll(m.WorkspaceDir, 0o755); err != nil {
 		return RestoreResult{}, fmt.Errorf("workspace snapshot restore: mkdir workspace: %w", err)
@@ -118,6 +230,39 @@ func (m *WorkspaceSnapshotManager) Restore(_ context.Context, req RestoreRequest
 		return RestoreResult{}, fmt.Errorf("workspace snapshot restore: restore %s: %w", req.SnapshotID, err)
 	}
 	return RestoreResult{SnapshotID: req.SnapshotID, Method: "full_copy"}, nil
+}
+
+func (m *WorkspaceSnapshotManager) registerPendingSnapshot(id string, done <-chan error) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	if m.pending == nil {
+		m.pending = map[string]<-chan error{}
+	}
+	m.pending[id] = done
+}
+
+func (m *WorkspaceSnapshotManager) clearPendingSnapshot(id string, done <-chan error) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	if m.pending[id] == done {
+		delete(m.pending, id)
+	}
+}
+
+func (m *WorkspaceSnapshotManager) waitPendingSnapshot(ctx context.Context, id string) error {
+	m.pendingMu.Lock()
+	done := m.pending[id]
+	m.pendingMu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case err := <-done:
+		m.clearPendingSnapshot(id, done)
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (m *WorkspaceSnapshotManager) nextSnapshotID(req SnapshotRequest) string {

--- a/internal/core/snapshot_ctime_linux.go
+++ b/internal/core/snapshot_ctime_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package core
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileChangeTime(info os.FileInfo) (int64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return stat.Ctim.Nano(), true
+}

--- a/internal/core/snapshot_ctime_other.go
+++ b/internal/core/snapshot_ctime_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package core
+
+import "os"
+
+func fileChangeTime(_ os.FileInfo) (int64, bool) {
+	return 0, false
+}

--- a/internal/core/snapshot_delta.go
+++ b/internal/core/snapshot_delta.go
@@ -1,0 +1,380 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	snapshotManifestFile = ".v100snapshot.json"
+	snapshotMarkerFile   = ".v100snapshot.format"
+	snapshotMarkerValue  = "v100-delta-snapshot-v1"
+	snapshotContentDir   = "content"
+	snapshotFormat       = 1
+)
+
+type snapshotManifest struct {
+	Version int            `json:"version"`
+	ID      string         `json:"id"`
+	Method  string         `json:"method"`
+	BaseID  string         `json:"base_id,omitempty"`
+	Dirs    []snapshotDir  `json:"dirs,omitempty"`
+	Files   []snapshotFile `json:"files,omitempty"`
+	Links   []snapshotLink `json:"links,omitempty"`
+}
+
+type snapshotDir struct {
+	Path string `json:"path"`
+	Mode uint32 `json:"mode"`
+}
+
+type snapshotFile struct {
+	Path    string `json:"path"`
+	Digest  string `json:"digest"`
+	Size    int64  `json:"size"`
+	Mode    uint32 `json:"mode"`
+	ModTime int64  `json:"mod_time_unix_nano"`
+	CTime   int64  `json:"change_time_unix_nano,omitempty"`
+	CTimeOK bool   `json:"change_time_available,omitempty"`
+}
+
+type snapshotLink struct {
+	Path   string `json:"path"`
+	Target string `json:"target"`
+}
+
+func (m *WorkspaceSnapshotManager) captureDelta(ctx context.Context, id string) (SnapshotResult, error) {
+	dst := filepath.Join(m.SnapshotRoot, id)
+	if err := os.RemoveAll(dst); err != nil {
+		return SnapshotResult{}, fmt.Errorf("workspace snapshot: clear %s: %w", dst, err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return SnapshotResult{}, fmt.Errorf("workspace snapshot: mkdir %s: %w", dst, err)
+	}
+	contentRoot := m.contentRoot()
+	if err := os.MkdirAll(contentRoot, 0o755); err != nil {
+		return SnapshotResult{}, fmt.Errorf("workspace snapshot: mkdir content store: %w", err)
+	}
+
+	baseByPath := map[string]snapshotFile{}
+	baseID := ""
+	if m.lastManifest != nil {
+		baseID = m.lastManifest.ID
+		for _, f := range m.lastManifest.Files {
+			baseByPath[f.Path] = f
+		}
+	}
+
+	manifest := &snapshotManifest{
+		Version: snapshotFormat,
+		ID:      id,
+		Method:  string(SnapshotModeDelta),
+		BaseID:  baseID,
+	}
+	filter := newWorkspaceFilter(m.WorkspaceDir)
+	err := filepath.Walk(m.WorkspaceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		rel, err := filepath.Rel(m.WorkspaceDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if filter.Skip(rel, info) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if info.IsDir() {
+			manifest.Dirs = append(manifest.Dirs, snapshotDir{
+				Path: rel,
+				Mode: uint32(info.Mode().Perm()),
+			})
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			manifest.Links = append(manifest.Links, snapshotLink{
+				Path:   rel,
+				Target: target,
+			})
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		ctime, ctimeOK := fileChangeTime(info)
+		file := snapshotFile{
+			Path:    rel,
+			Size:    info.Size(),
+			Mode:    uint32(info.Mode().Perm()),
+			ModTime: info.ModTime().UnixNano(),
+			CTime:   ctime,
+			CTimeOK: ctimeOK,
+		}
+		if previous, ok := baseByPath[rel]; ok && sameSnapshotFileState(previous, file) && m.contentExists(previous.Digest) {
+			file.Digest = previous.Digest
+		} else {
+			digest, size, err := m.storeContent(ctx, path)
+			if err != nil {
+				return err
+			}
+			file.Digest = digest
+			file.Size = size
+		}
+		manifest.Files = append(manifest.Files, file)
+		return nil
+	})
+	if err != nil {
+		return SnapshotResult{}, fmt.Errorf("workspace snapshot: capture %s: %w", id, err)
+	}
+	sort.Slice(manifest.Dirs, func(i, j int) bool { return manifest.Dirs[i].Path < manifest.Dirs[j].Path })
+	sort.Slice(manifest.Files, func(i, j int) bool { return manifest.Files[i].Path < manifest.Files[j].Path })
+	sort.Slice(manifest.Links, func(i, j int) bool { return manifest.Links[i].Path < manifest.Links[j].Path })
+
+	if err := writeSnapshotManifest(dst, manifest); err != nil {
+		return SnapshotResult{}, fmt.Errorf("workspace snapshot: write manifest: %w", err)
+	}
+	m.lastManifest = manifest
+	return SnapshotResult{ID: id, Method: string(SnapshotModeDelta)}, nil
+}
+
+func (m *WorkspaceSnapshotManager) restoreDelta(ctx context.Context, manifest *snapshotManifest) error {
+	if err := os.MkdirAll(m.WorkspaceDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir workspace: %w", err)
+	}
+	if err := clearDir(m.WorkspaceDir); err != nil {
+		return fmt.Errorf("clear workspace: %w", err)
+	}
+	for _, dir := range manifest.Dirs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		target := filepath.Join(m.WorkspaceDir, filepath.FromSlash(dir.Path))
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			return err
+		}
+	}
+	for _, link := range manifest.Links {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		target := filepath.Join(m.WorkspaceDir, filepath.FromSlash(link.Path))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.Symlink(link.Target, target); err != nil {
+			return err
+		}
+	}
+	for _, file := range manifest.Files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		src := m.contentPath(file.Digest)
+		target := filepath.Join(m.WorkspaceDir, filepath.FromSlash(file.Path))
+		if err := copyFileWithContext(ctx, src, target, os.FileMode(file.Mode)); err != nil {
+			return err
+		}
+		if file.ModTime > 0 {
+			ts := time.Unix(0, file.ModTime)
+			_ = os.Chtimes(target, ts, ts)
+		}
+	}
+	for i := len(manifest.Dirs) - 1; i >= 0; i-- {
+		dir := manifest.Dirs[i]
+		target := filepath.Join(m.WorkspaceDir, filepath.FromSlash(dir.Path))
+		_ = os.Chmod(target, os.FileMode(dir.Mode))
+	}
+	return nil
+}
+
+func sameSnapshotFileState(a, b snapshotFile) bool {
+	if strings.TrimSpace(a.Digest) == "" {
+		return false
+	}
+	if a.Size != b.Size || a.Mode != b.Mode || a.ModTime != b.ModTime {
+		return false
+	}
+	if !a.CTimeOK || !b.CTimeOK {
+		return false
+	}
+	return a.CTime == b.CTime
+}
+
+func (m *WorkspaceSnapshotManager) contentRoot() string {
+	return filepath.Join(m.SnapshotRoot, snapshotContentDir)
+}
+
+func (m *WorkspaceSnapshotManager) contentPath(digest string) string {
+	return filepath.Join(m.contentRoot(), digest)
+}
+
+func (m *WorkspaceSnapshotManager) contentExists(digest string) bool {
+	if strings.TrimSpace(digest) == "" {
+		return false
+	}
+	_, err := os.Stat(m.contentPath(digest))
+	return err == nil
+}
+
+func (m *WorkspaceSnapshotManager) storeContent(ctx context.Context, src string) (string, int64, error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp, err := os.CreateTemp(m.contentRoot(), ".tmp-*")
+	if err != nil {
+		return "", 0, err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	hash := sha256.New()
+	size, err := copyHashingWithContext(ctx, in, tmp, hash)
+	closeErr := tmp.Close()
+	if err != nil {
+		return "", 0, err
+	}
+	if closeErr != nil {
+		return "", 0, closeErr
+	}
+
+	digest := hex.EncodeToString(hash.Sum(nil))
+	finalPath := m.contentPath(digest)
+	if _, err := os.Stat(finalPath); err == nil {
+		return digest, size, nil
+	}
+	if err := os.Chmod(tmpPath, 0o444); err != nil {
+		return "", 0, err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return "", 0, err
+	}
+	return digest, size, nil
+}
+
+func copyHashingWithContext(ctx context.Context, in io.Reader, out io.Writer, hash io.Writer) (int64, error) {
+	buf := make([]byte, 128*1024)
+	var written int64
+	for {
+		if ctx.Err() != nil {
+			return written, ctx.Err()
+		}
+		n, readErr := in.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if _, err := hash.Write(chunk); err != nil {
+				return written, err
+			}
+			if _, err := out.Write(chunk); err != nil {
+				return written, err
+			}
+			written += int64(n)
+		}
+		if readErr == io.EOF {
+			return written, nil
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
+}
+
+func copyFileWithContext(ctx context.Context, src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := copyWithContext(ctx, in, out); err != nil {
+		return err
+	}
+	return os.Chmod(dst, mode)
+}
+
+func copyWithContext(ctx context.Context, in io.Reader, out io.Writer) (int64, error) {
+	buf := make([]byte, 128*1024)
+	var written int64
+	for {
+		if ctx.Err() != nil {
+			return written, ctx.Err()
+		}
+		n, readErr := in.Read(buf)
+		if n > 0 {
+			if _, err := out.Write(buf[:n]); err != nil {
+				return written, err
+			}
+			written += int64(n)
+		}
+		if readErr == io.EOF {
+			return written, nil
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
+}
+
+func writeSnapshotManifest(snapshotDir string, manifest *snapshotManifest) error {
+	b, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(snapshotDir, snapshotManifestFile), append(b, '\n'), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(snapshotDir, snapshotMarkerFile), []byte(snapshotMarkerValue+"\n"), 0o644)
+}
+
+func isDeltaSnapshotDir(snapshotDir string) bool {
+	b, err := os.ReadFile(filepath.Join(snapshotDir, snapshotMarkerFile))
+	return err == nil && strings.TrimSpace(string(b)) == snapshotMarkerValue
+}
+
+func readSnapshotManifest(snapshotDir string) (*snapshotManifest, error) {
+	b, err := os.ReadFile(filepath.Join(snapshotDir, snapshotManifestFile))
+	if err != nil {
+		return nil, err
+	}
+	var manifest snapshotManifest
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.Version != snapshotFormat {
+		return nil, fmt.Errorf("unsupported snapshot manifest version %d", manifest.Version)
+	}
+	return &manifest, nil
+}

--- a/internal/core/snapshot_delta_test.go
+++ b/internal/core/snapshot_delta_test.go
@@ -1,0 +1,570 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNoopSnapshotManager(t *testing.T) {
+	mgr := NoopSnapshotManager{}
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "call-1"})
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if snap.ID != "noop-call-1" || snap.Method != "noop" {
+		t.Fatalf("noop capture = %#v", snap)
+	}
+	restore, err := mgr.Restore(context.Background(), RestoreRequest{})
+	if err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if restore.SnapshotID != "noop" || restore.Method != "noop" {
+		t.Fatalf("noop restore = %#v", restore)
+	}
+	async, err := mgr.CaptureAsync(context.Background(), SnapshotRequest{CallID: "async"})
+	if err != nil {
+		t.Fatalf("CaptureAsync returned error: %v", err)
+	}
+	if async.Result.ID != "noop-async" || async.Result.Method != "noop" {
+		t.Fatalf("noop async capture = %#v", async.Result)
+	}
+	select {
+	case err := <-async.Done:
+		if err != nil {
+			t.Fatalf("noop async returned error: %v", err)
+		}
+	default:
+		t.Fatal("noop async did not complete immediately")
+	}
+}
+
+func TestWorkspaceSnapshotDeltaRestoreAndDedup(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+
+	writeSnapshotTestFile(t, workspace, "a.txt", "alpha\n")
+	writeSnapshotTestFile(t, workspace, "b.txt", "shared\n")
+	if err := os.MkdirAll(filepath.Join(workspace, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	firstState := readWorkspaceState(t, workspace)
+
+	snap1, err := mgr.Capture(context.Background(), SnapshotRequest{StepID: "s1", CallID: "c1"})
+	if err != nil {
+		t.Fatalf("Capture 1 returned error: %v", err)
+	}
+	if snap1.Method != string(SnapshotModeDelta) {
+		t.Fatalf("Capture 1 method = %q, want delta", snap1.Method)
+	}
+	manifest1 := readManifestForTest(t, snapshotRoot, snap1.ID)
+	if manifest1.BaseID != "" {
+		t.Fatalf("first snapshot base id = %q, want empty", manifest1.BaseID)
+	}
+
+	time.Sleep(time.Millisecond)
+	writeSnapshotTestFile(t, workspace, "a.txt", "beta\n")
+	if err := os.Remove(filepath.Join(workspace, "b.txt")); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotTestFile(t, workspace, "nested/c.txt", "shared\n")
+	secondState := readWorkspaceState(t, workspace)
+
+	snap2, err := mgr.Capture(context.Background(), SnapshotRequest{StepID: "s2", CallID: "c2"})
+	if err != nil {
+		t.Fatalf("Capture 2 returned error: %v", err)
+	}
+	manifest2 := readManifestForTest(t, snapshotRoot, snap2.ID)
+	if manifest2.BaseID != snap1.ID {
+		t.Fatalf("second snapshot base id = %q, want %q", manifest2.BaseID, snap1.ID)
+	}
+	if hasManifestPath(manifest2, "b.txt") {
+		t.Fatal("deleted file b.txt is still present in delta manifest")
+	}
+	if !hasManifestPath(manifest2, "nested/c.txt") {
+		t.Fatal("added file nested/c.txt missing from delta manifest")
+	}
+
+	if got := countContentBlobs(t, snapshotRoot); got != 3 {
+		t.Fatalf("content blob count = %d, want 3 unique contents", got)
+	}
+
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap1.ID}); err != nil {
+		t.Fatalf("Restore 1 returned error: %v", err)
+	}
+	if got := readWorkspaceState(t, workspace); !sameWorkspaceState(got, firstState) {
+		t.Fatalf("restore 1 mismatch\ngot:  %#v\nwant: %#v", got, firstState)
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap2.ID}); err != nil {
+		t.Fatalf("Restore 2 returned error: %v", err)
+	}
+	if got := readWorkspaceState(t, workspace); !sameWorkspaceState(got, secondState) {
+		t.Fatalf("restore 2 mismatch\ngot:  %#v\nwant: %#v", got, secondState)
+	}
+}
+
+func TestWorkspaceSnapshotDeltaDetectsChangedContentWithRestoredMtime(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	writeSnapshotTestFile(t, workspace, "state.txt", "before")
+	path := filepath.Join(workspace, "state.txt")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := info.ModTime()
+	if _, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "before"}); err != nil {
+		t.Fatalf("Capture before returned error: %v", err)
+	}
+
+	writeSnapshotTestFile(t, workspace, "state.txt", "after!")
+	if err := os.Chtimes(path, ts, ts); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "after"})
+	if err != nil {
+		t.Fatalf("Capture after returned error: %v", err)
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "after!" {
+		t.Fatalf("restored data = %q, want changed content", data)
+	}
+}
+
+func TestWorkspaceSnapshotDeltaRehashesWhenChangeTimeUnavailable(t *testing.T) {
+	previous := snapshotFile{
+		Path:    "state.txt",
+		Digest:  "abc123",
+		Size:    6,
+		Mode:    0o644,
+		ModTime: 1234,
+		CTimeOK: false,
+	}
+	current := snapshotFile{
+		Path:    "state.txt",
+		Size:    6,
+		Mode:    0o644,
+		ModTime: 1234,
+		CTimeOK: false,
+	}
+	if sameSnapshotFileState(previous, current) {
+		t.Fatal("mtime-only snapshot state was treated as unchanged")
+	}
+}
+
+func TestWorkspaceSnapshotDeltaRestoresSymlinks(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	writeSnapshotTestFile(t, workspace, "target.txt", "target\n")
+	linkPath := filepath.Join(workspace, "link.txt")
+	if err := os.Symlink("target.txt", linkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "links"})
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	manifest := readManifestForTest(t, snapshotRoot, snap.ID)
+	if len(manifest.Links) != 1 || manifest.Links[0].Path != "link.txt" || manifest.Links[0].Target != "target.txt" {
+		t.Fatalf("manifest links = %#v", manifest.Links)
+	}
+
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotTestFile(t, workspace, "link.txt", "regular\n")
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("link.txt mode = %v, want symlink", info.Mode())
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "target.txt" {
+		t.Fatalf("symlink target = %q, want target.txt", target)
+	}
+}
+
+func TestWorkspaceSnapshotDeltaRestoresFilesInsideRestrictiveDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode-only directory permissions are not portable on windows")
+	}
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	dir := filepath.Join(workspace, "readonly")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotTestFile(t, workspace, "readonly/state.txt", "locked\n")
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o755) }()
+
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "readonly"})
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := clearDir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "readonly", "state.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "locked\n" {
+		t.Fatalf("restored data = %q, want locked", data)
+	}
+	info, err := os.Stat(filepath.Join(workspace, "readonly"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o555 {
+		t.Fatalf("restored directory mode = %v, want 0555", got)
+	}
+}
+
+func TestWorkspaceSnapshotValidationAndErrors(t *testing.T) {
+	empty := &WorkspaceSnapshotManager{}
+	if _, err := empty.Capture(context.Background(), SnapshotRequest{}); err == nil {
+		t.Fatal("Capture returned nil error for empty manager")
+	}
+	if _, err := empty.CaptureAsync(context.Background(), SnapshotRequest{}); err == nil {
+		t.Fatal("CaptureAsync returned nil error for empty manager")
+	}
+
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{}); err == nil {
+		t.Fatal("Restore returned nil error for empty snapshot id")
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: "missing"}); err == nil {
+		t.Fatal("Restore returned nil error for missing snapshot")
+	}
+
+	badSnapshot := filepath.Join(snapshotRoot, "bad")
+	if err := os.MkdirAll(badSnapshot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badSnapshot, snapshotManifestFile), []byte("{bad"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badSnapshot, snapshotMarkerFile), []byte(snapshotMarkerValue+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: "bad"}); err == nil {
+		t.Fatal("Restore returned nil error for malformed manifest")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := mgr.Capture(ctx, SnapshotRequest{CallID: "canceled"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Capture error = %v, want context canceled", err)
+	}
+}
+
+func TestWorkspaceSnapshotManifestValidation(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeSnapshotManifest(dir, &snapshotManifest{Version: snapshotFormat, ID: "ok", Method: string(SnapshotModeDelta)}); err != nil {
+		t.Fatalf("writeSnapshotManifest returned error: %v", err)
+	}
+	if _, err := readSnapshotManifest(dir); err != nil {
+		t.Fatalf("readSnapshotManifest returned error: %v", err)
+	}
+	if err := writeSnapshotManifest(dir, &snapshotManifest{Version: 999, ID: "bad"}); err != nil {
+		t.Fatalf("writeSnapshotManifest returned error: %v", err)
+	}
+	if _, err := readSnapshotManifest(dir); err == nil {
+		t.Fatal("readSnapshotManifest returned nil error for unsupported version")
+	}
+}
+
+func TestWorkspaceSnapshotContextAwareCopy(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := copyWithContext(ctx, strings.NewReader("data"), io.Discard); !errors.Is(err, context.Canceled) {
+		t.Fatalf("copyWithContext error = %v, want context canceled", err)
+	}
+	var out bytes.Buffer
+	var hash bytes.Buffer
+	if _, err := copyHashingWithContext(ctx, strings.NewReader("data"), &out, &hash); !errors.Is(err, context.Canceled) {
+		t.Fatalf("copyHashingWithContext error = %v, want context canceled", err)
+	}
+}
+
+func TestSanitizeSnapshotComponent(t *testing.T) {
+	got := sanitizeSnapshotComponent(" step/with\\spaces ")
+	if got != "step-with-spaces" {
+		t.Fatalf("sanitizeSnapshotComponent() = %q", got)
+	}
+	if got := sanitizeSnapshotComponent(" "); got != "" {
+		t.Fatalf("sanitizeSnapshotComponent(blank) = %q, want empty", got)
+	}
+}
+
+func TestWorkspaceSnapshotFullCopyMode(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManagerWithOptions(workspace, snapshotRoot, WorkspaceSnapshotOptions{Mode: SnapshotModeFullCopy})
+	writeSnapshotTestFile(t, workspace, "state.txt", "before\n")
+
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "full"})
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if snap.Method != string(SnapshotModeFullCopy) {
+		t.Fatalf("method = %q, want full_copy", snap.Method)
+	}
+	writeSnapshotTestFile(t, workspace, "state.txt", "after\n")
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "state.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "before\n" {
+		t.Fatalf("restored state = %q, want before", data)
+	}
+}
+
+func TestWorkspaceSnapshotFullCopyAllowsRootManifestFile(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManagerWithOptions(workspace, snapshotRoot, WorkspaceSnapshotOptions{Mode: SnapshotModeFullCopy})
+	if err := os.WriteFile(filepath.Join(workspace, snapshotManifestFile), []byte("{bad"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "full"})
+	if err != nil {
+		t.Fatalf("Capture returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, snapshotManifestFile), []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: snap.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, snapshotManifestFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "{bad" {
+		t.Fatalf("restored marker-like file = %q, want original", data)
+	}
+}
+
+func TestWorkspaceSnapshotCaptureAsync(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	writeSnapshotTestFile(t, workspace, "state.txt", "async\n")
+
+	async, err := mgr.CaptureAsync(context.Background(), SnapshotRequest{CallID: "async"})
+	if err != nil {
+		t.Fatalf("CaptureAsync returned error: %v", err)
+	}
+	if !strings.HasSuffix(async.Result.Method, "_async") {
+		t.Fatalf("async method = %q, want *_async", async.Result.Method)
+	}
+	select {
+	case err := <-async.Done:
+		if err != nil {
+			t.Fatalf("async snapshot failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async snapshot")
+	}
+	if _, err := mgr.Restore(context.Background(), RestoreRequest{SnapshotID: async.Result.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+}
+
+func TestWorkspaceSnapshotRestoreWaitsForPendingAsyncCapture(t *testing.T) {
+	workspace := t.TempDir()
+	snapshotRoot := filepath.Join(t.TempDir(), "snapshots")
+	mgr := NewWorkspaceSnapshotManager(workspace, snapshotRoot)
+	writeSnapshotTestFile(t, workspace, "state.txt", "async\n")
+
+	async, err := mgr.CaptureAsync(context.Background(), SnapshotRequest{CallID: "async"})
+	if err != nil {
+		t.Fatalf("CaptureAsync returned error: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := mgr.Restore(ctx, RestoreRequest{SnapshotID: async.Result.ID}); err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "state.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "async\n" {
+		t.Fatalf("restored data = %q, want async", data)
+	}
+}
+
+func BenchmarkWorkspaceSnapshotFullVsDelta100MB(b *testing.B) {
+	workspace := b.TempDir()
+	for i := 0; i < 100; i++ {
+		name := filepath.Join(workspace, "data", "file-"+leftPad3(i)+".bin")
+		if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(name, bytes.Repeat([]byte{byte(i)}, 1024*1024), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.Run("full_copy", func(b *testing.B) {
+		mgr := NewWorkspaceSnapshotManagerWithOptions(workspace, filepath.Join(b.TempDir(), "snapshots"), WorkspaceSnapshotOptions{Mode: SnapshotModeFullCopy})
+		for i := 0; i < b.N; i++ {
+			if _, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: strconv.Itoa(i)}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("delta_one_file_changed", func(b *testing.B) {
+		mgr := NewWorkspaceSnapshotManager(workspace, filepath.Join(b.TempDir(), "snapshots"))
+		if _, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: "base"}); err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			writeSnapshotTestFile(b, workspace, "data/file-000.bin", "changed-"+strconv.Itoa(i))
+			if _, err := mgr.Capture(context.Background(), SnapshotRequest{CallID: strconv.Itoa(i)}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func writeSnapshotTestFile(t testing.TB, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readManifestForTest(t *testing.T, root, id string) *snapshotManifest {
+	t.Helper()
+	manifest, err := readSnapshotManifest(filepath.Join(root, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func hasManifestPath(manifest *snapshotManifest, path string) bool {
+	for _, f := range manifest.Files {
+		if f.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func countContentBlobs(t *testing.T, root string) int {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(root, snapshotContentDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && !strings.HasPrefix(entry.Name(), ".tmp-") {
+			count++
+		}
+	}
+	return count
+}
+
+func readWorkspaceState(t *testing.T, root string) map[string]string {
+	t.Helper()
+	state := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if info.IsDir() {
+			state[rel+"/"] = ""
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		state[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func sameWorkspaceState(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		if b[k] != av {
+			return false
+		}
+	}
+	return true
+}
+
+func leftPad3(i int) string {
+	s := strconv.Itoa(i)
+	for len(s) < 3 {
+		s = "0" + s
+	}
+	return s
+}


### PR DESCRIPTION
Closes #220

## Summary
- changes `WorkspaceSnapshotManager` default storage to delta snapshots backed by manifests plus a content-addressed blob store
- reuses unchanged file digests, deduplicates identical file contents, and restores workspaces from manifests
- adds full-copy mode for comparison plus `CaptureAsync` for non-preimage background backups
- adds Linux ctime to delta signatures so changed content is detected even if mtime is restored
- documents delta vs full snapshots in `AGENTS.md`

## Verification
- `./scripts/lint.sh`
- `env GOCACHE=/tmp/v100-issue220-gocache go test ./...`
  - sandboxed run failed on expected sandbox limits: `/home/v/.config` read-only and httptest localhost bind denied
  - reran the same command with approval outside the sandbox: passed
- `env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue220 GIT_WORK_TREE=/tmp/v100-issue220 GOCACHE=/tmp/v100-issue220-gocache go build ./...`
- `env GOCACHE=/tmp/v100-issue220-gocache go test -coverprofile=/tmp/v100-issue220-core.cover ./internal/core`
- snapshot I/O coverage across `snapshot.go`, `snapshot_delta.go`, and ctime helpers: 81.1% (245/302 statements)
- `env GOCACHE=/tmp/v100-issue220-gocache go test ./internal/core -run '^$' -bench BenchmarkWorkspaceSnapshotFullVsDelta100MB -benchtime=1x -count=1`
  - full_copy: 67,738,309 ns/op
  - delta_one_file_changed: 2,828,582 ns/op

Note: plain `go build ./...` in the isolated `/tmp` worktree failed only at Go VCS stamping. The final build keeps VCS stamping enabled by passing the explicit Git worktree metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delta snapshot mode with content-addressed storage and deduplication
  * Asynchronous snapshot capture for non-blocking backups
  * Option to choose full-copy snapshot mode

* **Documentation**
  * Added workspace snapshots guide: modes, storage layout, and restore semantics

* **Bug Fixes**
  * Restore now waits for in-progress snapshots before applying

* **Tests**
  * Extensive snapshot capture/restore tests and a benchmark; export/archive now includes snapshot trees in exports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->