### PR TITLE
feat: complete ACP lifecycle

### DIFF
--- a/cmd/v100/cmd_acp.go
+++ b/cmd/v100/cmd_acp.go
@@ -58,6 +58,8 @@ type acpServer struct {
 	initialized      bool
 	clientInfo       acp.ClientInfo
 	clientCaps       acp.ClientCapabilities
+	shutdown         chan struct{}
+	shutdownOnce     sync.Once
 	mu               sync.Mutex
 	cfgPath          string
 	cmd              *cobra.Command
@@ -72,42 +74,70 @@ type acpSession struct {
 	mu           sync.Mutex
 	closing      bool
 	prompts      []acp.SuggestedPrompt
+	cleanupDone  chan struct{}
+	cleanupOnce  sync.Once
 }
 
 func (s *acpServer) serve() error {
+	shutdown := s.shutdownChan()
+	messages := make(chan []byte)
+	readErrs := make(chan error, 1)
+
+	go func() {
+		for {
+			msg, err := s.conn.ReadMessage()
+			if err != nil {
+				select {
+				case readErrs <- err:
+				case <-shutdown:
+				}
+				return
+			}
+			msg = append([]byte(nil), msg...)
+			select {
+			case messages <- msg:
+			case <-shutdown:
+				return
+			}
+		}
+	}()
+
 	for {
-		msg, err := s.conn.ReadMessage()
-		if err != nil {
+		select {
+		case <-shutdown:
+			return nil
+		case err := <-readErrs:
 			if err == io.EOF {
 				return nil
 			}
 			return err
-		}
+		case msg := <-messages:
+			var req acp.Request
+			if err := json.Unmarshal(msg, &req); err != nil {
+				_ = s.conn.SendError(nil, acp.ErrParse, acp.ErrorMessage(acp.ErrParse))
+				continue
+			}
 
-		var req acp.Request
-		if err := json.Unmarshal(msg, &req); err != nil {
-			_ = s.conn.SendError(nil, acp.ErrParse, acp.ErrorMessage(acp.ErrParse))
-			continue
-		}
-
-		if req.ID != nil {
-			go s.handleRequest(req)
-		} else {
-			go s.handleNotification(req)
+			if req.ID != nil {
+				go s.handleRequest(req)
+			} else {
+				go s.handleNotification(req)
+			}
 		}
 	}
 }
 
 func (s *acpServer) handleRequest(req acp.Request) {
+	if req.Method != acp.MethodFinalize && s.isShuttingDown() {
+		_ = s.conn.SendError(req.ID, acp.ErrInvalidRequest, "ACP server has finalized")
+		return
+	}
+
 	switch req.Method {
 	case acp.MethodInitialize:
 		var params acp.InitializeParams
 		if err := decodeACPParams(req.Params, &params); err != nil {
 			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
-			return
-		}
-		if params.ProtocolVersion != 0 && params.ProtocolVersion != acp.ProtocolVersion {
-			_ = s.conn.SendError(req.ID, acp.ErrUnsupportedProtocolVersion, fmt.Sprintf("%s: client=%d supported=%d", acp.ErrorMessage(acp.ErrUnsupportedProtocolVersion), params.ProtocolVersion, acp.ProtocolVersion))
 			return
 		}
 		res := acp.InitializeResult{
@@ -144,6 +174,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		}
 		closed := s.finalize()
 		_ = s.conn.SendResponse(req.ID, acp.FinalizeResult{ClosedSessions: closed})
+		s.signalShutdown()
 
 	case acp.MethodSetSuggestedPrompts:
 		var params acp.SetSuggestedPromptsParams
@@ -294,14 +325,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		session.mu.Unlock()
 
 		defer func() {
-			session.mu.Lock()
-			session.promptActive = false
-			closing := session.closing
-			session.mu.Unlock()
-
-			if closing {
-				session.cleanup()
-			}
+			session.finishPrompt()
 		}()
 
 		var promptText string
@@ -391,6 +415,32 @@ func decodeACPParams(raw json.RawMessage, dest any) error {
 	return json.Unmarshal(raw, dest)
 }
 
+func (s *acpServer) shutdownChan() chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown == nil {
+		s.shutdown = make(chan struct{})
+	}
+	return s.shutdown
+}
+
+func (s *acpServer) signalShutdown() {
+	ch := s.shutdownChan()
+	s.shutdownOnce.Do(func() {
+		close(ch)
+	})
+}
+
+func (s *acpServer) isShuttingDown() bool {
+	ch := s.shutdownChan()
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
 type acpStatusError struct {
 	code int
 	msg  string
@@ -458,6 +508,7 @@ func closeACPSession(session *acpSession) {
 	if session == nil {
 		return
 	}
+	cleanupDone := session.cleanupDoneChan()
 	session.mu.Lock()
 	session.closing = true
 	if session.cancel != nil {
@@ -467,6 +518,12 @@ func closeACPSession(session *acpSession) {
 	session.mu.Unlock()
 	if !active {
 		session.cleanup()
+		return
+	}
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(5 * time.Second):
 	}
 }
 
@@ -552,12 +609,35 @@ func (s *acpServer) runPrompt(session *acpSession, sessionID string, prompt stri
 }
 
 func (s *acpSession) cleanup() {
+	cleanupDone := s.cleanupDoneChan()
+	s.cleanupOnce.Do(func() {
+		s.mu.Lock()
+		comp := s.comp
+		s.comp = nil
+		s.loop = nil
+		s.mu.Unlock()
+		cleanupRunComponents(comp)
+		close(cleanupDone)
+	})
+}
+
+func (s *acpSession) cleanupDoneChan() chan struct{} {
 	s.mu.Lock()
-	comp := s.comp
-	s.comp = nil
-	s.loop = nil
+	defer s.mu.Unlock()
+	if s.cleanupDone == nil {
+		s.cleanupDone = make(chan struct{})
+	}
+	return s.cleanupDone
+}
+
+func (s *acpSession) finishPrompt() {
+	s.mu.Lock()
+	s.promptActive = false
+	closing := s.closing
 	s.mu.Unlock()
-	cleanupRunComponents(comp)
+	if closing {
+		s.cleanup()
+	}
 }
 
 func cleanupRunComponents(comp *RunComponents) {

--- a/cmd/v100/cmd_acp.go
+++ b/cmd/v100/cmd_acp.go
@@ -51,12 +51,16 @@ func acpCmd(cfgPath *string) *cobra.Command {
 }
 
 type acpServer struct {
-	conn     *acp.Conn
-	yolo     bool
-	sessions map[string]*acpSession
-	mu       sync.Mutex
-	cfgPath  string
-	cmd      *cobra.Command
+	conn             *acp.Conn
+	yolo             bool
+	sessions         map[string]*acpSession
+	suggestedPrompts []acp.SuggestedPrompt
+	initialized      bool
+	clientInfo       acp.ClientInfo
+	clientCaps       acp.ClientCapabilities
+	mu               sync.Mutex
+	cfgPath          string
+	cmd              *cobra.Command
 }
 
 type acpSession struct {
@@ -67,6 +71,7 @@ type acpSession struct {
 	promptActive bool
 	mu           sync.Mutex
 	closing      bool
+	prompts      []acp.SuggestedPrompt
 }
 
 func (s *acpServer) serve() error {
@@ -81,7 +86,7 @@ func (s *acpServer) serve() error {
 
 		var req acp.Request
 		if err := json.Unmarshal(msg, &req); err != nil {
-			_ = s.conn.SendError(nil, acp.ErrParse, "parse error")
+			_ = s.conn.SendError(nil, acp.ErrParse, acp.ErrorMessage(acp.ErrParse))
 			continue
 		}
 
@@ -95,9 +100,18 @@ func (s *acpServer) serve() error {
 
 func (s *acpServer) handleRequest(req acp.Request) {
 	switch req.Method {
-	case "initialize":
+	case acp.MethodInitialize:
+		var params acp.InitializeParams
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
+		if params.ProtocolVersion != 0 && params.ProtocolVersion != acp.ProtocolVersion {
+			_ = s.conn.SendError(req.ID, acp.ErrUnsupportedProtocolVersion, fmt.Sprintf("%s: client=%d supported=%d", acp.ErrorMessage(acp.ErrUnsupportedProtocolVersion), params.ProtocolVersion, acp.ProtocolVersion))
+			return
+		}
 		res := acp.InitializeResult{
-			ProtocolVersion: 1,
+			ProtocolVersion: acp.ProtocolVersion,
 			AgentCapabilities: acp.AgentCapabilities{
 				SessionCapabilities: acp.SessionCapabilities{
 					Close: &struct{}{},
@@ -114,16 +128,45 @@ func (s *acpServer) handleRequest(req acp.Request) {
 				res.AgentCapabilities.PromptCapabilities.Image = prov.Capabilities().Images
 			}
 		}
+		s.mu.Lock()
+		s.initialized = true
+		s.clientInfo = params.ClientInfo
+		s.clientCaps = params.ClientCapabilities
+		s.mu.Unlock()
 
 		_ = s.conn.SendResponse(req.ID, res)
 
-	case "session/new":
+	case acp.MethodFinalize:
+		var params acp.FinalizeParams
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
+		closed := s.finalize()
+		_ = s.conn.SendResponse(req.ID, acp.FinalizeResult{ClosedSessions: closed})
+
+	case acp.MethodSetSuggestedPrompts:
+		var params acp.SetSuggestedPromptsParams
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
+		if err := s.setSuggestedPrompts(params); err != nil {
+			_ = s.conn.SendError(req.ID, acpErrorCode(err), err.Error())
+			return
+		}
+		_ = s.conn.SendResponse(req.ID, acp.SetSuggestedPromptsResult{Count: len(params.Prompts)})
+
+	case acp.MethodSessionNew:
 		var params acp.SessionNewParams
-		_ = json.Unmarshal(req.Params, &params)
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
 
 		cfg, err := loadConfig(s.cfgPath)
 		if err != nil {
-			_ = s.conn.SendError(req.ID, acp.ErrInternal, err.Error())
+			_ = s.conn.SendError(req.ID, acp.ErrProviderConfiguration, err.Error())
 			return
 		}
 
@@ -140,7 +183,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 
 		comp, err := BuildRunComponents(cfg, opts)
 		if err != nil {
-			_ = s.conn.SendError(req.ID, acp.ErrInternal, err.Error())
+			_ = s.conn.SendError(req.ID, acp.ErrProviderConfiguration, err.Error())
 			return
 		}
 
@@ -189,16 +232,26 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		loop.Hooks = append(loop.Hooks, core.DeduplicationHook(2))
 
 		s.mu.Lock()
+		if _, exists := s.sessions[sessionID]; exists {
+			s.mu.Unlock()
+			cleanupRunComponents(comp)
+			_ = s.conn.SendError(req.ID, acp.ErrSessionAlreadyExists, fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionAlreadyExists), sessionID))
+			return
+		}
+		if s.sessions == nil {
+			s.sessions = make(map[string]*acpSession)
+		}
 		s.sessions[sessionID] = &acpSession{
-			comp: comp,
-			loop: loop,
+			comp:    comp,
+			loop:    loop,
+			prompts: copySuggestedPrompts(s.suggestedPrompts),
 		}
 		s.mu.Unlock()
 
 		_ = s.conn.SendResponse(req.ID, acp.SessionNewResult{SessionID: sessionID})
 
 		// Advertise available slash commands to the client
-		_ = s.conn.SendNotification("session/update", acp.SessionUpdateParams{
+		_ = s.conn.SendNotification(acp.MethodSessionUpdate, acp.SessionUpdateParams{
 			SessionID: sessionID,
 			Update: acp.Update{
 				Type: "available_commands_update",
@@ -210,28 +263,31 @@ func (s *acpServer) handleRequest(req acp.Request) {
 			},
 		})
 
-	case "session/prompt":
+	case acp.MethodSessionPrompt:
 		var params acp.SessionPromptParams
-		_ = json.Unmarshal(req.Params, &params)
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
 
 		s.mu.Lock()
 		session, ok := s.sessions[params.SessionID]
 		s.mu.Unlock()
 
 		if !ok {
-			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, "session not found")
+			_ = s.conn.SendError(req.ID, acp.ErrSessionNotFound, fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionNotFound), params.SessionID))
 			return
 		}
 
 		session.mu.Lock()
 		if session.closing {
 			session.mu.Unlock()
-			_ = s.conn.SendError(req.ID, acp.ErrInternal, "session is closing")
+			_ = s.conn.SendError(req.ID, acp.ErrSessionClosing, fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionClosing), params.SessionID))
 			return
 		}
 		if session.promptActive {
 			session.mu.Unlock()
-			_ = s.conn.SendError(req.ID, acp.ErrInternal, "a prompt turn is already active for this session")
+			_ = s.conn.SendError(req.ID, acp.ErrSessionBusy, fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionBusy), params.SessionID))
 			return
 		}
 		session.promptActive = true
@@ -278,11 +334,14 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		stopReason := s.runPrompt(session, params.SessionID, promptText, images)
 		_ = s.conn.SendResponse(req.ID, acp.SessionPromptResult{StopReason: stopReason})
 
-	case "session/close":
+	case acp.MethodSessionClose:
 		var params struct {
 			SessionID string `json:"sessionId"`
 		}
-		_ = json.Unmarshal(req.Params, &params)
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			_ = s.conn.SendError(req.ID, acp.ErrInvalidParams, err.Error())
+			return
+		}
 
 		s.mu.Lock()
 		session, ok := s.sessions[params.SessionID]
@@ -291,31 +350,25 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		}
 		s.mu.Unlock()
 
-		if ok {
-			session.mu.Lock()
-			session.closing = true
-			if session.cancel != nil {
-				session.cancel()
-			}
-			active := session.promptActive
-			session.mu.Unlock()
-
-			if !active {
-				session.cleanup()
-			}
+		if !ok {
+			_ = s.conn.SendError(req.ID, acp.ErrSessionNotFound, fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionNotFound), params.SessionID))
+			return
 		}
+		closeACPSession(session)
 		_ = s.conn.SendResponse(req.ID, nil)
 
 	default:
-		_ = s.conn.SendError(req.ID, acp.ErrMethodNotFound, "method not found")
+		_ = s.conn.SendError(req.ID, acp.ErrMethodNotFound, acp.ErrorMessage(acp.ErrMethodNotFound))
 	}
 }
 
 func (s *acpServer) handleNotification(req acp.Request) {
 	switch req.Method {
-	case "session/cancel":
+	case acp.MethodSessionCancel:
 		var params acp.SessionCancelParams
-		_ = json.Unmarshal(req.Params, &params)
+		if err := decodeACPParams(req.Params, &params); err != nil {
+			return
+		}
 
 		s.mu.Lock()
 		session, ok := s.sessions[params.SessionID]
@@ -329,6 +382,104 @@ func (s *acpServer) handleNotification(req acp.Request) {
 			session.mu.Unlock()
 		}
 	}
+}
+
+func decodeACPParams(raw json.RawMessage, dest any) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	return json.Unmarshal(raw, dest)
+}
+
+type acpStatusError struct {
+	code int
+	msg  string
+}
+
+func (e acpStatusError) Error() string { return e.msg }
+
+func acpErrorCode(err error) int {
+	if e, ok := err.(acpStatusError); ok {
+		return e.code
+	}
+	return acp.ErrInternal
+}
+
+func (s *acpServer) setSuggestedPrompts(params acp.SetSuggestedPromptsParams) error {
+	prompts := copySuggestedPrompts(params.Prompts)
+	if params.SessionID == "" {
+		s.mu.Lock()
+		s.suggestedPrompts = prompts
+		s.mu.Unlock()
+		return nil
+	}
+
+	s.mu.Lock()
+	session, ok := s.sessions[params.SessionID]
+	s.mu.Unlock()
+	if !ok {
+		return acpStatusError{
+			code: acp.ErrSessionNotFound,
+			msg:  fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionNotFound), params.SessionID),
+		}
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.closing {
+		return acpStatusError{
+			code: acp.ErrSessionClosing,
+			msg:  fmt.Sprintf("%s: %s", acp.ErrorMessage(acp.ErrSessionClosing), params.SessionID),
+		}
+	}
+	session.prompts = prompts
+	return nil
+}
+
+func (s *acpServer) finalize() int {
+	s.mu.Lock()
+	sessions := s.sessions
+	s.sessions = make(map[string]*acpSession)
+	s.suggestedPrompts = nil
+	s.initialized = false
+	s.clientInfo = acp.ClientInfo{}
+	s.clientCaps = acp.ClientCapabilities{}
+	s.mu.Unlock()
+
+	closed := 0
+	for _, session := range sessions {
+		closeACPSession(session)
+		closed++
+	}
+	return closed
+}
+
+func closeACPSession(session *acpSession) {
+	if session == nil {
+		return
+	}
+	session.mu.Lock()
+	session.closing = true
+	if session.cancel != nil {
+		session.cancel()
+	}
+	active := session.promptActive
+	session.mu.Unlock()
+	if !active {
+		session.cleanup()
+	}
+}
+
+func copySuggestedPrompts(in []acp.SuggestedPrompt) []acp.SuggestedPrompt {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]acp.SuggestedPrompt, len(in))
+	copy(out, in)
+	for i := range out {
+		out[i].Tags = append([]string(nil), in[i].Tags...)
+	}
+	return out
 }
 
 func (s *acpServer) runPrompt(session *acpSession, sessionID string, prompt string, images []providers.ImageAttachment) string {
@@ -348,7 +499,7 @@ func (s *acpServer) runPrompt(session *acpSession, sessionID string, prompt stri
 
 	cfg, err := loadConfig(s.cfgPath)
 	if err != nil {
-		_ = s.conn.SendNotification("session/update", acp.SessionUpdateParams{
+		_ = s.conn.SendNotification(acp.MethodSessionUpdate, acp.SessionUpdateParams{
 			SessionID: sessionID,
 			Update: acp.Update{
 				Type: "agent_message_chunk",
@@ -362,7 +513,7 @@ func (s *acpServer) runPrompt(session *acpSession, sessionID string, prompt stri
 	}
 	rewritten, handled, err := applyInteractiveMode(ctx, cfg, session.loop, prompt, false)
 	if err != nil {
-		_ = s.conn.SendNotification("session/update", acp.SessionUpdateParams{
+		_ = s.conn.SendNotification(acp.MethodSessionUpdate, acp.SessionUpdateParams{
 			SessionID: sessionID,
 			Update: acp.Update{
 				Type: "agent_message_chunk",
@@ -402,14 +553,21 @@ func (s *acpServer) runPrompt(session *acpSession, sessionID string, prompt stri
 
 func (s *acpSession) cleanup() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	comp := s.comp
+	s.comp = nil
+	s.loop = nil
+	s.mu.Unlock()
+	cleanupRunComponents(comp)
+}
 
-	if s.comp != nil {
-		if s.comp.Trace != nil {
-			_ = s.comp.Trace.Close()
-		}
-		if s.comp.Config != nil && s.comp.Config.Sandbox.Enabled && s.comp.Session != nil {
-			_ = s.comp.Session.Close()
-		}
+func cleanupRunComponents(comp *RunComponents) {
+	if comp == nil {
+		return
+	}
+	if comp.Trace != nil {
+		_ = comp.Trace.Close()
+	}
+	if comp.Config != nil && comp.Config.Sandbox.Enabled && comp.Session != nil {
+		_ = comp.Session.Close()
 	}
 }

--- a/cmd/v100/cmd_acp_test.go
+++ b/cmd/v100/cmd_acp_test.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/tripledoublev/v100/internal/acp"
 	"github.com/tripledoublev/v100/internal/config"
 	"github.com/tripledoublev/v100/internal/core"
@@ -27,7 +32,7 @@ func TestACPLifecycleInitializeSuggestedPromptsFinalize(t *testing.T) {
 		ClientInfo:      acp.ClientInfo{Name: "test-client", Version: "1.0.0"},
 		ClientCapabilities: acp.ClientCapabilities{
 			Terminal: true,
-			FS:       map[string]bool{"read": true},
+			FS:       map[string]bool{"readTextFile": true},
 		},
 	}))
 	responses := acpResponses(t, out.String())
@@ -95,6 +100,149 @@ func TestACPLifecycleInitializeSuggestedPromptsFinalize(t *testing.T) {
 	}
 }
 
+func TestACPServeStdioLifecycleFinalizeStopsServer(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[providers.llamacpp]
+type = "llamacpp"
+default_model = "test-model"
+base_url = "http://127.0.0.1:19091/v1"
+
+[embedding]
+provider = "llamacpp"
+model = "test-model"
+
+[defaults]
+provider = "llamacpp"
+cheap_provider = "llamacpp"
+smart_provider = "llamacpp"
+compress_provider = "llamacpp"
+confirm_tools = "dangerous"
+budget_steps = 1
+budget_tokens = 1000
+max_tool_calls_per_step = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inReader, inWriter := io.Pipe()
+	outReader, outWriter := io.Pipe()
+	server := &acpServer{
+		conn:     acp.NewConn(inReader, outWriter),
+		sessions: make(map[string]*acpSession),
+		cfgPath:  cfgPath,
+		cmd:      &cobra.Command{},
+	}
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.serve()
+	}()
+	defer func() {
+		_ = inWriter.Close()
+		_ = outReader.Close()
+		_ = outWriter.Close()
+	}()
+
+	scanner := bufio.NewScanner(outReader)
+
+	writeACPRequest(t, inWriter, 1, acp.MethodInitialize, acp.InitializeParams{
+		ProtocolVersion: acp.ProtocolVersion + 1,
+		ClientInfo:      acp.ClientInfo{Name: "stdio-test", Version: "1.0.0"},
+		ClientCapabilities: acp.ClientCapabilities{
+			Terminal: true,
+			FS:       map[string]bool{"readTextFile": true, "writeTextFile": true},
+		},
+	})
+	var initResult acp.InitializeResult
+	readACPResponse(t, scanner, 1, &initResult)
+	if initResult.ProtocolVersion != acp.ProtocolVersion {
+		t.Fatalf("negotiated protocol version = %d, want %d", initResult.ProtocolVersion, acp.ProtocolVersion)
+	}
+
+	writeACPRequest(t, inWriter, 2, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{
+		Prompts: []acp.SuggestedPrompt{{
+			ID:     "orient",
+			Title:  "Orient",
+			Prompt: "Summarize the workspace.",
+		}},
+	})
+	var prompts acp.SetSuggestedPromptsResult
+	readACPResponse(t, scanner, 2, &prompts)
+	if prompts.Count != 1 {
+		t.Fatalf("prompt count = %d, want 1", prompts.Count)
+	}
+
+	writeACPRequest(t, inWriter, 3, acp.MethodSessionNew, acp.SessionNewParams{CWD: workDir})
+	var session acp.SessionNewResult
+	readACPResponse(t, scanner, 3, &session)
+	if session.SessionID == "" {
+		t.Fatal("empty session ID")
+	}
+
+	writeACPRequest(t, inWriter, 4, acp.MethodSessionPrompt, acp.SessionPromptParams{
+		SessionID: session.SessionID,
+		Prompt: []acp.ContentBlock{{
+			Type: "text",
+			Text: "/llamacpp",
+		}},
+	})
+	var prompt acp.SessionPromptResult
+	readACPResponse(t, scanner, 4, &prompt)
+	if prompt.StopReason != "end_turn" {
+		t.Fatalf("stop reason = %q, want end_turn", prompt.StopReason)
+	}
+
+	writeACPRequest(t, inWriter, 5, acp.MethodFinalize, acp.FinalizeParams{Reason: "test complete"})
+	var final acp.FinalizeResult
+	readACPResponse(t, scanner, 5, &final)
+	if final.ClosedSessions != 1 {
+		t.Fatalf("closed sessions = %d, want 1", final.ClosedSessions)
+	}
+
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return after finalize")
+	}
+}
+
+func TestCloseACPSessionWaitsForActivePromptCleanup(t *testing.T) {
+	trace, err := core.OpenTrace(filepath.Join(t.TempDir(), "trace.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeSession := &fakeACPSession{}
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &acpSession{
+		comp: &RunComponents{
+			Config:  &config.Config{Sandbox: config.SandboxConfig{Enabled: true}},
+			Trace:   trace,
+			Session: fakeSession,
+		},
+		cancel:       cancel,
+		activeCtx:    ctx,
+		promptActive: true,
+	}
+
+	go func() {
+		<-ctx.Done()
+		time.Sleep(25 * time.Millisecond)
+		session.finishPrompt()
+	}()
+
+	closeACPSession(session)
+	if !fakeSession.closed {
+		t.Fatal("active session cleanup did not complete before close returned")
+	}
+}
+
 func TestACPErrorsUseProtocolCodes(t *testing.T) {
 	var out bytes.Buffer
 	server := &acpServer{
@@ -102,12 +250,11 @@ func TestACPErrorsUseProtocolCodes(t *testing.T) {
 		sessions: make(map[string]*acpSession),
 	}
 
-	server.handleRequest(acpRequest(t, 1, acp.MethodInitialize, acp.InitializeParams{ProtocolVersion: acp.ProtocolVersion + 1}))
-	server.handleRequest(acpRequest(t, 2, acp.MethodSessionPrompt, acp.SessionPromptParams{SessionID: "missing"}))
-	server.handleRequest(acpRequest(t, 3, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{SessionID: "missing"}))
+	server.handleRequest(acpRequest(t, 1, acp.MethodSessionPrompt, acp.SessionPromptParams{SessionID: "missing"}))
+	server.handleRequest(acpRequest(t, 2, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{SessionID: "missing"}))
 
 	responses := acpResponses(t, out.String())
-	wantCodes := []int{acp.ErrUnsupportedProtocolVersion, acp.ErrSessionNotFound, acp.ErrSessionNotFound}
+	wantCodes := []int{acp.ErrSessionNotFound, acp.ErrSessionNotFound}
 	if len(responses) != len(wantCodes) {
 		t.Fatalf("responses = %#v", responses)
 	}
@@ -125,6 +272,28 @@ func acpRequest(t *testing.T, id int, method string, params any) acp.Request {
 		t.Fatal(err)
 	}
 	return acp.Request{JSONRPC: acp.JSONRPCVersion, Method: method, Params: raw, ID: id}
+}
+
+func writeACPRequest(t *testing.T, w io.Writer, id int, method string, params any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(acpRequest(t, id, method, params)); err != nil {
+		t.Fatalf("write ACP request %s: %v", method, err)
+	}
+}
+
+func readACPResponse(t *testing.T, scanner *bufio.Scanner, id int, dest any) {
+	t.Helper()
+	for scanner.Scan() {
+		var res acp.Response
+		if err := json.Unmarshal(scanner.Bytes(), &res); err == nil && res.ID == float64(id) {
+			decodeACPResult(t, res, dest)
+			return
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read ACP response %d: %v", id, err)
+	}
+	t.Fatalf("ACP response %d not found before stream ended", id)
 }
 
 func acpResponses(t *testing.T, raw string) []acp.Response {

--- a/cmd/v100/cmd_acp_test.go
+++ b/cmd/v100/cmd_acp_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tripledoublev/v100/internal/acp"
+	"github.com/tripledoublev/v100/internal/config"
+	"github.com/tripledoublev/v100/internal/core"
+	"github.com/tripledoublev/v100/internal/core/executor"
+)
+
+func TestACPLifecycleInitializeSuggestedPromptsFinalize(t *testing.T) {
+	var out bytes.Buffer
+	server := &acpServer{
+		conn:     acp.NewConn(strings.NewReader(""), &out),
+		sessions: make(map[string]*acpSession),
+		cfgPath:  filepath.Join(t.TempDir(), "config.toml"),
+	}
+
+	server.handleRequest(acpRequest(t, 1, acp.MethodInitialize, acp.InitializeParams{
+		ProtocolVersion: acp.ProtocolVersion,
+		ClientInfo:      acp.ClientInfo{Name: "test-client", Version: "1.0.0"},
+		ClientCapabilities: acp.ClientCapabilities{
+			Terminal: true,
+			FS:       map[string]bool{"read": true},
+		},
+	}))
+	responses := acpResponses(t, out.String())
+	if len(responses) != 1 {
+		t.Fatalf("responses = %#v", responses)
+	}
+	var initResult acp.InitializeResult
+	decodeACPResult(t, responses[0], &initResult)
+	if initResult.ProtocolVersion != acp.ProtocolVersion || initResult.AgentInfo.Name != "v100" {
+		t.Fatalf("initialize result = %#v", initResult)
+	}
+	if !server.initialized || server.clientInfo.Name != "test-client" || !server.clientCaps.Terminal {
+		t.Fatalf("server handshake state not recorded: %#v %#v", server.clientInfo, server.clientCaps)
+	}
+
+	prompts := []acp.SuggestedPrompt{{
+		ID:     "fix",
+		Title:  "Fix failing tests",
+		Prompt: "Run the focused test and repair the failing assertion.",
+		Tags:   []string{"test"},
+	}}
+	server.handleRequest(acpRequest(t, 2, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{
+		Prompts: prompts,
+	}))
+	responses = acpResponses(t, out.String())
+	var setGlobal acp.SetSuggestedPromptsResult
+	decodeACPResult(t, responses[1], &setGlobal)
+	if setGlobal.Count != 1 || len(server.suggestedPrompts) != 1 {
+		t.Fatalf("global prompts not stored: result=%#v prompts=%#v", setGlobal, server.suggestedPrompts)
+	}
+
+	trace, err := core.OpenTrace(filepath.Join(t.TempDir(), "trace.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeSession := &fakeACPSession{}
+	server.sessions["session-1"] = &acpSession{
+		comp: &RunComponents{
+			Config:  &config.Config{Sandbox: config.SandboxConfig{Enabled: true}},
+			Trace:   trace,
+			Session: fakeSession,
+		},
+		prompts: copySuggestedPrompts(server.suggestedPrompts),
+	}
+	server.handleRequest(acpRequest(t, 3, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{
+		SessionID: "session-1",
+		Prompts:   prompts,
+	}))
+	if got := server.sessions["session-1"].prompts[0].Title; got != "Fix failing tests" {
+		t.Fatalf("session prompt title = %q", got)
+	}
+
+	server.handleRequest(acpRequest(t, 4, acp.MethodFinalize, acp.FinalizeParams{Reason: "test"}))
+	responses = acpResponses(t, out.String())
+	var finalized acp.FinalizeResult
+	decodeACPResult(t, responses[3], &finalized)
+	if finalized.ClosedSessions != 1 {
+		t.Fatalf("finalize result = %#v", finalized)
+	}
+	if !fakeSession.closed {
+		t.Fatal("finalize did not close sandbox session")
+	}
+	if server.initialized || len(server.sessions) != 0 || len(server.suggestedPrompts) != 0 {
+		t.Fatalf("server not finalized: initialized=%v sessions=%d prompts=%d", server.initialized, len(server.sessions), len(server.suggestedPrompts))
+	}
+}
+
+func TestACPErrorsUseProtocolCodes(t *testing.T) {
+	var out bytes.Buffer
+	server := &acpServer{
+		conn:     acp.NewConn(strings.NewReader(""), &out),
+		sessions: make(map[string]*acpSession),
+	}
+
+	server.handleRequest(acpRequest(t, 1, acp.MethodInitialize, acp.InitializeParams{ProtocolVersion: acp.ProtocolVersion + 1}))
+	server.handleRequest(acpRequest(t, 2, acp.MethodSessionPrompt, acp.SessionPromptParams{SessionID: "missing"}))
+	server.handleRequest(acpRequest(t, 3, acp.MethodSetSuggestedPrompts, acp.SetSuggestedPromptsParams{SessionID: "missing"}))
+
+	responses := acpResponses(t, out.String())
+	wantCodes := []int{acp.ErrUnsupportedProtocolVersion, acp.ErrSessionNotFound, acp.ErrSessionNotFound}
+	if len(responses) != len(wantCodes) {
+		t.Fatalf("responses = %#v", responses)
+	}
+	for i, want := range wantCodes {
+		if responses[i].Error == nil || responses[i].Error.Code != want {
+			t.Fatalf("response %d error = %#v, want code %d", i, responses[i].Error, want)
+		}
+	}
+}
+
+func acpRequest(t *testing.T, id int, method string, params any) acp.Request {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return acp.Request{JSONRPC: acp.JSONRPCVersion, Method: method, Params: raw, ID: id}
+}
+
+func acpResponses(t *testing.T, raw string) []acp.Response {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	out := make([]acp.Response, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var res acp.Response
+		if err := json.Unmarshal([]byte(line), &res); err != nil {
+			t.Fatalf("response unmarshal %q: %v", line, err)
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+func decodeACPResult(t *testing.T, res acp.Response, dest any) {
+	t.Helper()
+	if res.Error != nil {
+		t.Fatalf("response error = %#v", res.Error)
+	}
+	if err := json.Unmarshal(res.Result, dest); err != nil {
+		t.Fatalf("result unmarshal: %v", err)
+	}
+}
+
+type fakeACPSession struct {
+	closed bool
+}
+
+func (s *fakeACPSession) ID() string { return "fake" }
+
+func (s *fakeACPSession) Type() string { return "host" }
+
+func (s *fakeACPSession) Start(context.Context) error { return nil }
+
+func (s *fakeACPSession) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *fakeACPSession) Run(context.Context, executor.RunRequest) (executor.Result, error) {
+	return executor.Result{}, nil
+}
+
+func (s *fakeACPSession) Workspace() string { return "" }
+
+var _ executor.Session = (*fakeACPSession)(nil)

--- a/docs/acp-client-guide.md
+++ b/docs/acp-client-guide.md
@@ -1,0 +1,185 @@
+# ACP Client Guide
+
+v100 exposes Agent Client Protocol (ACP) over newline-delimited JSON-RPC 2.0 on
+stdio:
+
+```sh
+v100 acp
+```
+
+Each request is one JSON object followed by `\n`. Responses and notifications
+are also one object per line. v100 reserves normal JSON-RPC errors for protocol
+syntax and uses the JSON-RPC server error range for lifecycle/session failures.
+
+## Lifecycle
+
+1. Send `initialize`.
+2. Optionally send `set_suggested_prompts` to seed global or session-specific
+   prompts.
+3. Create a session with `session/new`.
+4. Send work to the session with `session/prompt`.
+5. Close individual sessions with `session/close`, or shut down the ACP server
+   with `finalize`.
+
+### initialize
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": 1,
+    "clientInfo": { "name": "example-client", "version": "0.1.0" },
+    "clientCapabilities": {
+      "terminal": true,
+      "fs": { "read": true, "write": true }
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": 1,
+    "agentInfo": { "name": "v100", "version": "..." },
+    "agentCapabilities": {
+      "promptCapabilities": { "image": true },
+      "sessionCapabilities": { "close": {} }
+    }
+  }
+}
+```
+
+If the client sends a nonzero protocol version other than `1`, v100 returns
+`-32010` (`unsupported protocol version`).
+
+### set_suggested_prompts
+
+Use this to publish prompt shortcuts before or after session creation. Omit
+`sessionId` to set global defaults for future sessions. Include `sessionId` to
+replace prompts for that session.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "set_suggested_prompts",
+  "params": {
+    "prompts": [
+      {
+        "id": "fix-tests",
+        "title": "Fix tests",
+        "description": "Run focused tests and repair the failing path.",
+        "prompt": "Run the focused failing test and make the smallest fix.",
+        "tags": ["test", "repair"]
+      }
+    ]
+  }
+}
+```
+
+Response:
+
+```json
+{ "jsonrpc": "2.0", "id": 2, "result": { "count": 1 } }
+```
+
+### session/new
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/new",
+  "params": { "cwd": "/path/to/workspace" }
+}
+```
+
+Response:
+
+```json
+{ "jsonrpc": "2.0", "id": 3, "result": { "sessionId": "run-..." } }
+```
+
+v100 may also send `session/update` notifications with available slash commands.
+
+### session/prompt
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "session/prompt",
+  "params": {
+    "sessionId": "run-...",
+    "prompt": [{ "type": "text", "text": "Summarize this repository." }]
+  }
+}
+```
+
+Responses return a stop reason:
+
+```json
+{ "jsonrpc": "2.0", "id": 4, "result": { "stopReason": "end_turn" } }
+```
+
+During execution, v100 emits `session/update` notifications for model chunks,
+thought chunks, tool calls, and tool results.
+
+### session/close
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "session/close",
+  "params": { "sessionId": "run-..." }
+}
+```
+
+This cancels any active prompt for that session and releases trace/sandbox
+resources.
+
+### finalize
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "finalize",
+  "params": { "reason": "client shutdown" }
+}
+```
+
+Response:
+
+```json
+{ "jsonrpc": "2.0", "id": 6, "result": { "closedSessions": 1 } }
+```
+
+`finalize` cancels active sessions, closes inactive sessions immediately, clears
+server lifecycle state, and returns the number of sessions it shut down.
+
+## Error Codes
+
+| Code | Meaning |
+| --- | --- |
+| `-32700` | Parse error |
+| `-32600` | Invalid request |
+| `-32601` | Method not found |
+| `-32602` | Invalid params |
+| `-32603` | Internal error |
+| `-32001` | Session not found |
+| `-32002` | Session already exists |
+| `-32003` | Session busy |
+| `-32004` | Session closing |
+| `-32010` | Unsupported protocol version |
+| `-32020` | Provider configuration error |

--- a/docs/acp-client-guide.md
+++ b/docs/acp-client-guide.md
@@ -35,7 +35,7 @@ Request:
     "clientInfo": { "name": "example-client", "version": "0.1.0" },
     "clientCapabilities": {
       "terminal": true,
-      "fs": { "read": true, "write": true }
+      "fs": { "readTextFile": true, "writeTextFile": true }
     }
   }
 }
@@ -58,8 +58,9 @@ Response:
 }
 ```
 
-If the client sends a nonzero protocol version other than `1`, v100 returns
-`-32010` (`unsupported protocol version`).
+If the client sends a protocol version v100 does not support, v100 responds with
+its latest supported protocol version. Clients that cannot speak that version
+should close the connection.
 
 ### set_suggested_prompts
 
@@ -166,7 +167,8 @@ Response:
 ```
 
 `finalize` cancels active sessions, closes inactive sessions immediately, clears
-server lifecycle state, and returns the number of sessions it shut down.
+server lifecycle state, returns the number of sessions it shut down, and then
+terminates the ACP server process.
 
 ## Error Codes
 
@@ -181,5 +183,4 @@ server lifecycle state, and returns the number of sessions it shut down.
 | `-32002` | Session already exists |
 | `-32003` | Session busy |
 | `-32004` | Session closing |
-| `-32010` | Unsupported protocol version |
 | `-32020` | Provider configuration error |

--- a/docs/examples/acp_client_stub.py
+++ b/docs/examples/acp_client_stub.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Minimal JSON-RPC ACP client for v100.
+
+Run from a repository root:
+
+    python3 docs/examples/acp_client_stub.py
+
+The script starts `v100 acp`, initializes the connection, creates a session,
+sends one text prompt, and finalizes the server.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def send(proc: subprocess.Popen[str], request: dict) -> dict:
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    proc.stdin.write(json.dumps(request) + "\n")
+    proc.stdin.flush()
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("v100 acp exited before responding")
+        message = json.loads(line)
+        if message.get("id") == request.get("id"):
+            if message.get("error"):
+                raise RuntimeError(f"ACP error: {message['error']}")
+            return message
+        print(f"notification: {message}", file=sys.stderr)
+
+
+def main() -> int:
+    workspace = str(Path.cwd())
+    proc = subprocess.Popen(
+        ["v100", "acp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        text=True,
+    )
+    try:
+        init = send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientInfo": {"name": "v100-acp-stub", "version": "0.1.0"},
+                    "clientCapabilities": {"terminal": True, "fs": {"read": True}},
+                },
+            },
+        )
+        print(f"initialized: {init['result']['agentInfo']}")
+
+        send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "set_suggested_prompts",
+                "params": {
+                    "prompts": [
+                        {
+                            "id": "summarize",
+                            "title": "Summarize repo",
+                            "prompt": "Summarize the current repository structure.",
+                            "tags": ["orientation"],
+                        }
+                    ]
+                },
+            },
+        )
+
+        session = send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/new",
+                "params": {"cwd": workspace},
+            },
+        )["result"]["sessionId"]
+        print(f"session: {session}")
+
+        prompt = send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session,
+                    "prompt": [{"type": "text", "text": "Summarize this repository."}],
+                },
+            },
+        )
+        print(f"stop reason: {prompt['result']['stopReason']}")
+
+        final = send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "finalize",
+                "params": {"reason": "stub complete"},
+            },
+        )
+        print(f"closed sessions: {final['result']['closedSessions']}")
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/examples/acp_client_stub.py
+++ b/docs/examples/acp_client_stub.py
@@ -53,7 +53,10 @@ def main() -> int:
                 "params": {
                     "protocolVersion": 1,
                     "clientInfo": {"name": "v100-acp-stub", "version": "0.1.0"},
-                    "clientCapabilities": {"terminal": True, "fs": {"read": True}},
+                    "clientCapabilities": {
+                        "terminal": True,
+                        "fs": {"readTextFile": True},
+                    },
                 },
             },
         )

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -33,12 +33,64 @@ type Error struct {
 }
 
 const (
+	JSONRPCVersion  = "2.0"
+	ProtocolVersion = 1
+)
+
+const (
+	MethodInitialize          = "initialize"
+	MethodFinalize            = "finalize"
+	MethodSetSuggestedPrompts = "set_suggested_prompts"
+	MethodSessionNew          = "session/new"
+	MethodSessionPrompt       = "session/prompt"
+	MethodSessionClose        = "session/close"
+	MethodSessionCancel       = "session/cancel"
+	MethodSessionUpdate       = "session/update"
+)
+
+const (
 	ErrParse          = -32700
 	ErrInvalidRequest = -32600
 	ErrMethodNotFound = -32601
 	ErrInvalidParams  = -32602
 	ErrInternal       = -32603
+
+	ErrSessionNotFound            = -32001
+	ErrSessionAlreadyExists       = -32002
+	ErrSessionBusy                = -32003
+	ErrSessionClosing             = -32004
+	ErrUnsupportedProtocolVersion = -32010
+	ErrProviderConfiguration      = -32020
 )
+
+func ErrorMessage(code int) string {
+	switch code {
+	case ErrParse:
+		return "parse error"
+	case ErrInvalidRequest:
+		return "invalid request"
+	case ErrMethodNotFound:
+		return "method not found"
+	case ErrInvalidParams:
+		return "invalid params"
+	case ErrInternal:
+		return "internal error"
+	case ErrSessionNotFound:
+		return "session not found"
+	case ErrSessionAlreadyExists:
+		return "session already exists"
+	case ErrSessionBusy:
+		return "session busy"
+	case ErrSessionClosing:
+		return "session closing"
+	case ErrUnsupportedProtocolVersion:
+		return "unsupported protocol version"
+	case ErrProviderConfiguration:
+		return "provider configuration error"
+	default:
+		return "unknown error"
+	}
+}
 
 // ContentBlock Structures
 
@@ -80,6 +132,14 @@ type InitializeResult struct {
 	AgentInfo         AgentInfo         `json:"agentInfo"`
 }
 
+type FinalizeParams struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+type FinalizeResult struct {
+	ClosedSessions int `json:"closedSessions"`
+}
+
 type AgentInfo struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -110,6 +170,23 @@ type SessionNewParams struct {
 
 type SessionNewResult struct {
 	SessionID string `json:"sessionId"`
+}
+
+type SuggestedPrompt struct {
+	ID          string   `json:"id,omitempty"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Prompt      string   `json:"prompt"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+type SetSuggestedPromptsParams struct {
+	SessionID string            `json:"sessionId,omitempty"`
+	Prompts   []SuggestedPrompt `json:"prompts"`
+}
+
+type SetSuggestedPromptsResult struct {
+	Count int `json:"count"`
 }
 
 type SessionPromptParams struct {

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -1,0 +1,25 @@
+package acp
+
+import "testing"
+
+func TestErrorMessageCoversACPErrorCodes(t *testing.T) {
+	cases := map[int]string{
+		ErrParse:                      "parse error",
+		ErrInvalidRequest:             "invalid request",
+		ErrMethodNotFound:             "method not found",
+		ErrInvalidParams:              "invalid params",
+		ErrInternal:                   "internal error",
+		ErrSessionNotFound:            "session not found",
+		ErrSessionAlreadyExists:       "session already exists",
+		ErrSessionBusy:                "session busy",
+		ErrSessionClosing:             "session closing",
+		ErrUnsupportedProtocolVersion: "unsupported protocol version",
+		ErrProviderConfiguration:      "provider configuration error",
+		1234:                          "unknown error",
+	}
+	for code, want := range cases {
+		if got := ErrorMessage(code); got != want {
+			t.Fatalf("ErrorMessage(%d) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/internal/acp/translator.go
+++ b/internal/acp/translator.go
@@ -15,7 +15,7 @@ func NewTranslator(conn *Conn, sessionID string) core.OutputFn {
 				Text string `json:"text"`
 			}
 			if err := json.Unmarshal(ev.Payload, &p); err == nil {
-				_ = conn.SendNotification("session/update", SessionUpdateParams{
+				_ = conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{
 					SessionID: sessionID,
 					Update: Update{
 						Type: "agent_message_chunk",
@@ -30,7 +30,7 @@ func NewTranslator(conn *Conn, sessionID string) core.OutputFn {
 		case core.EventSolverPlan:
 			var plan string
 			if err := json.Unmarshal(ev.Payload, &plan); err == nil {
-				_ = conn.SendNotification("session/update", SessionUpdateParams{
+				_ = conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{
 					SessionID: sessionID,
 					Update: Update{
 						Type: "agent_thought_chunk",
@@ -49,7 +49,7 @@ func NewTranslator(conn *Conn, sessionID string) core.OutputFn {
 				if text == "" {
 					text = p.Error
 				}
-				_ = conn.SendNotification("session/update", SessionUpdateParams{
+				_ = conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{
 					SessionID: sessionID,
 					Update: Update{
 						Type: "agent_thought_chunk",
@@ -81,7 +81,7 @@ func NewTranslator(conn *Conn, sessionID string) core.OutputFn {
 					rawInput = json.RawMessage(marshaled)
 				}
 
-				_ = conn.SendNotification("session/update", SessionUpdateParams{
+				_ = conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{
 					SessionID: sessionID,
 					Update: Update{
 						Type:       "tool_call",
@@ -105,7 +105,7 @@ func NewTranslator(conn *Conn, sessionID string) core.OutputFn {
 					Output string `json:"output"`
 				}{Output: p.Output})
 
-				_ = conn.SendNotification("session/update", SessionUpdateParams{
+				_ = conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{
 					SessionID: sessionID,
 					Update: Update{
 						Type:       "tool_call_update",

--- a/internal/acp/translator_test.go
+++ b/internal/acp/translator_test.go
@@ -1,0 +1,71 @@
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tripledoublev/v100/internal/core"
+)
+
+func TestTranslatorMapsCoreEventsToSessionUpdates(t *testing.T) {
+	var out bytes.Buffer
+	conn := NewConn(strings.NewReader(""), &out)
+	translate := NewTranslator(conn, "session-1")
+
+	translate(acpEvent(t, core.EventModelToken, map[string]string{"text": "hello"}))
+	translate(acpRawEvent(t, core.EventSolverPlan, "plan text"))
+	translate(acpEvent(t, core.EventToolCall, core.ToolCallPayload{CallID: "call-1", Name: "fs_write", Args: `{"path":"a.txt"}`}))
+	translate(acpEvent(t, core.EventToolResult, core.ToolResultPayload{CallID: "call-1", Name: "fs_write", OK: false, Output: "denied"}))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("got %d notifications, want 4:\n%s", len(lines), out.String())
+	}
+	var got []SessionUpdateParams
+	for _, line := range lines {
+		var notif Notification
+		if err := json.Unmarshal([]byte(line), &notif); err != nil {
+			t.Fatalf("notification unmarshal: %v", err)
+		}
+		if notif.Method != MethodSessionUpdate {
+			t.Fatalf("notification method = %q, want %q", notif.Method, MethodSessionUpdate)
+		}
+		var params SessionUpdateParams
+		if err := json.Unmarshal(notif.Params, &params); err != nil {
+			t.Fatalf("params unmarshal: %v", err)
+		}
+		got = append(got, params)
+	}
+	if got[0].Update.Type != "agent_message_chunk" || got[0].Update.Content.Text != "hello" {
+		t.Fatalf("model token update = %#v", got[0].Update)
+	}
+	if got[1].Update.Type != "agent_thought_chunk" || got[1].Update.Content.Text != "plan text" {
+		t.Fatalf("plan update = %#v", got[1].Update)
+	}
+	if got[2].Update.Type != "tool_call" || got[2].Update.Kind != "edit" {
+		t.Fatalf("tool call update = %#v", got[2].Update)
+	}
+	if got[3].Update.Type != "tool_call_update" || got[3].Update.Status != "failed" {
+		t.Fatalf("tool result update = %#v", got[3].Update)
+	}
+}
+
+func acpEvent(t *testing.T, typ core.EventType, payload any) core.Event {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return core.Event{Type: typ, Payload: raw}
+}
+
+func acpRawEvent(t *testing.T, typ core.EventType, payload any) core.Event {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return core.Event{Type: typ, Payload: raw}
+}

--- a/internal/acp/transport.go
+++ b/internal/acp/transport.go
@@ -42,7 +42,7 @@ func (c *Conn) ReadMessage() ([]byte, error) {
 // SendResponse sends a JSON-RPC response.
 func (c *Conn) SendResponse(id any, result any) error {
 	res := Response{
-		JSONRPC: "2.0",
+		JSONRPC: JSONRPCVersion,
 		ID:      id,
 	}
 	if result != nil {
@@ -58,7 +58,7 @@ func (c *Conn) SendResponse(id any, result any) error {
 // SendError sends a JSON-RPC error response.
 func (c *Conn) SendError(id any, code int, message string) error {
 	res := Response{
-		JSONRPC: "2.0",
+		JSONRPC: JSONRPCVersion,
 		ID:      id,
 		Error: &Error{
 			Code:    code,
@@ -71,7 +71,7 @@ func (c *Conn) SendError(id any, code int, message string) error {
 // SendNotification sends a JSON-RPC notification.
 func (c *Conn) SendNotification(method string, params any) error {
 	notif := Notification{
-		JSONRPC: "2.0",
+		JSONRPC: JSONRPCVersion,
 		Method:  method,
 	}
 	if params != nil {

--- a/internal/acp/transport_test.go
+++ b/internal/acp/transport_test.go
@@ -1,0 +1,61 @@
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConnReadMessageAndWritesJSONRPC(t *testing.T) {
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":1}` + "\n")
+	var out bytes.Buffer
+	conn := NewConn(in, &out)
+
+	msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage returned error: %v", err)
+	}
+	if !strings.Contains(string(msg), MethodInitialize) {
+		t.Fatalf("ReadMessage = %s", msg)
+	}
+	if _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("ReadMessage returned nil error at EOF")
+	}
+
+	if err := conn.SendResponse(1, InitializeResult{ProtocolVersion: ProtocolVersion}); err != nil {
+		t.Fatalf("SendResponse returned error: %v", err)
+	}
+	if err := conn.SendError(2, ErrSessionNotFound, ErrorMessage(ErrSessionNotFound)); err != nil {
+		t.Fatalf("SendError returned error: %v", err)
+	}
+	if err := conn.SendNotification(MethodSessionUpdate, SessionUpdateParams{SessionID: "s1"}); err != nil {
+		t.Fatalf("SendNotification returned error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("wrote %d lines, want 3:\n%s", len(lines), out.String())
+	}
+	var res Response
+	if err := json.Unmarshal([]byte(lines[0]), &res); err != nil {
+		t.Fatalf("response unmarshal: %v", err)
+	}
+	if res.JSONRPC != JSONRPCVersion || len(res.Result) == 0 || res.ID == nil {
+		t.Fatalf("response = %#v", res)
+	}
+	var errRes Response
+	if err := json.Unmarshal([]byte(lines[1]), &errRes); err != nil {
+		t.Fatalf("error response unmarshal: %v", err)
+	}
+	if errRes.Error == nil || errRes.Error.Code != ErrSessionNotFound {
+		t.Fatalf("error response = %#v", errRes)
+	}
+	var notif Notification
+	if err := json.Unmarshal([]byte(lines[2]), &notif); err != nil {
+		t.Fatalf("notification unmarshal: %v", err)
+	}
+	if notif.JSONRPC != JSONRPCVersion || notif.Method != MethodSessionUpdate {
+		t.Fatalf("notification = %#v", notif)
+	}
+}


### PR DESCRIPTION
## Summary
- add ACP protocol constants, lifecycle payloads, and v100-specific JSON-RPC error codes
- implement initialize version negotiation, finalize shutdown/cleanup, and set_suggested_prompts handling in the ACP server
- add stdio JSON-RPC lifecycle coverage for initialize, suggested prompts, session/new, session/prompt, and finalize process shutdown
- add ACP client guide and example CLI stub using the current ACP filesystem capability names

Fixes #222

## Verification
- ./scripts/lint.sh
- env GOCACHE=/tmp/v100-issue222-gocache go test ./cmd/v100 -run 'TestACP|TestCloseACP'
- env GOCACHE=/tmp/v100-issue222-gocache go test -race ./cmd/v100 -run 'TestACP|TestCloseACP'
- env GOCACHE=/tmp/v100-issue222-gocache go test -coverprofile=/tmp/v100-issue222-acp.cover ./internal/acp (83.1% coverage)
- env GOCACHE=/tmp/v100-issue222-gocache go test ./... (passed outside sandbox; sandboxed full run failed on read-only /home/v/.config test fixture write)
- env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue222 GIT_WORK_TREE=/tmp/v100-issue222 GOCACHE=/tmp/v100-issue222-gocache go build ./...
