### PR TITLE
fix: harden oauth secret loading

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Model
+
+## Secret Resolution
+
+v100 resolves provider and OAuth client secrets in this order:
+
+1. Environment variables.
+2. Secret managers: 1Password (`op`), `pass`, then the system keyring.
+3. Legacy plaintext files under the v100 config directory, with a warning.
+
+Plaintext OAuth client credentials are not created by `v100 config init`.
+
+## OAuth Client Secrets
+
+Use environment variables when possible:
+
+- Codex/OpenAI OAuth client ID: `V100_CODEX_CLIENT_ID`, `CODEX_CLIENT_ID`, `OPENAI_CLIENT_ID`, or `OPENAI_OAUTH_CLIENT_ID`
+- Gemini OAuth client ID: `V100_GEMINI_CLIENT_ID`, `GEMINI_CLIENT_ID`, or `GOOGLE_OAUTH_CLIENT_ID`
+- Gemini OAuth client secret: `V100_GEMINI_CLIENT_SECRET`, `GEMINI_CLIENT_SECRET`, or `GOOGLE_OAUTH_CLIENT_SECRET`
+- MiniMax OAuth client ID: `V100_MINIMAX_CLIENT_ID` or `MINIMAX_CLIENT_ID`
+
+Secret manager keys:
+
+- `oauth_codex_client_id`
+- `oauth_gemini_client_id`
+- `oauth_gemini_client_secret`
+- `oauth_minimax_client_id`
+- `provider_anthropic_api_key`
+
+1Password uses `op read <prefix>/<key>`, where `V100_1PASSWORD_PREFIX`
+defaults to `op://Private/v100`. `pass` uses `pass show <prefix>/<key>`,
+where `V100_PASS_PREFIX` defaults to `v100`.
+
+On macOS, the system keyring uses `security find-generic-password`. On Linux,
+it uses `secret-tool lookup service v100 key <key>`.
+
+## Plaintext Fallback
+
+The legacy OAuth fallback path is `~/.config/v100/oauth_credentials.json`, or
+`$XDG_CONFIG_HOME/v100/oauth_credentials.json` when `XDG_CONFIG_HOME` is set.
+This path remains supported for compatibility, but every use emits a warning.
+Prefer environment variables or a secret manager for new installs.

--- a/cmd/v100/cmd_admin.go
+++ b/cmd/v100/cmd_admin.go
@@ -183,15 +183,13 @@ func configInitCmd() *cobra.Command {
 			credsPath := auth.DefaultCredentialsPath()
 			switch _, err := os.Stat(credsPath); {
 			case err == nil:
-				fmt.Println(ui.OK("OAuth client config found at " + credsPath))
+				fmt.Println(ui.Warn("Plaintext OAuth fallback exists at " + credsPath))
+				fmt.Println(ui.Dim("Prefer env vars or 1Password/pass/system keyring for OAuth client secrets."))
 			case os.IsNotExist(err):
-				if err := os.MkdirAll(filepath.Dir(credsPath), 0o700); err != nil {
-					return err
-				}
-				if err := os.WriteFile(credsPath, []byte(auth.CredentialsTemplate()), 0o600); err != nil {
-					return err
-				}
-				fmt.Println(ui.OK("OAuth client template written to " + credsPath))
+				fmt.Println(ui.OK("OAuth client secrets not written to disk by default"))
+				fmt.Println(ui.Dim("Set V100_CODEX_CLIENT_ID, V100_GEMINI_CLIENT_ID/V100_GEMINI_CLIENT_SECRET, or V100_MINIMAX_CLIENT_ID."))
+				fmt.Println(ui.Dim("Secret manager keys: oauth_codex_client_id, oauth_gemini_client_id, oauth_gemini_client_secret, oauth_minimax_client_id."))
+				fmt.Println(ui.Dim("Plaintext fallback remains supported with a warning at " + credsPath))
 			default:
 				return err
 			}
@@ -392,11 +390,12 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 			printOAuthConfigStatus := func(name string, err error) {
 				credsPath := auth.DefaultCredentialsPath()
 				if err == nil {
-					fmt.Println(ui.OK(fmt.Sprintf("Provider %s: OAuth client config at %s", name, credsPath)))
+					fmt.Println(ui.OK(fmt.Sprintf("Provider %s: OAuth client secrets resolved", name)))
 					return
 				}
-				fmt.Println(ui.Fail(fmt.Sprintf("Provider %s: OAuth client config invalid at %s", name, credsPath)))
+				fmt.Println(ui.Fail(fmt.Sprintf("Provider %s: OAuth client secrets missing", name)))
 				fmt.Println(ui.Dim("  " + strings.ReplaceAll(err.Error(), "\n", "\n  ")))
+				fmt.Println(ui.Dim("  Plaintext fallback path: " + credsPath))
 				ok = false
 			}
 
@@ -508,21 +507,17 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 					if authEnv == "" {
 						authEnv = "ANTHROPIC_API_KEY"
 					}
-					// Check stored key first, then env var
 					var anthropicKey string
 					tokenPath := auth.DefaultClaudeTokenPath()
-					if ct, err := auth.LoadClaude(tokenPath); err == nil && ct.Valid() {
+					if ct, err := auth.LoadClaudeWithEnv(tokenPath, authEnv); err == nil && ct.Valid() {
 						hint := ct.APIKey
 						anthropicKey = ct.APIKey
 						if len(hint) > 12 {
 							hint = hint[:8] + "..." + hint[len(hint)-4:]
 						}
-						fmt.Println(ui.OK(fmt.Sprintf("Provider %s: stored key at %s (%s)", name, tokenPath, hint)))
-					} else if key := os.Getenv(authEnv); key != "" {
-						anthropicKey = key
-						fmt.Println(ui.OK(fmt.Sprintf("Provider %s: %s set (%d chars)", name, authEnv, len(key))))
+						fmt.Println(ui.OK(fmt.Sprintf("Provider %s: API key resolved (%s)", name, hint)))
 					} else {
-						providerIssue(name, fmt.Sprintf("Provider %s: no key — run 'v100 login --provider anthropic' or set %s", name, authEnv))
+						providerIssue(name, fmt.Sprintf("Provider %s: no key — set %s, store provider_anthropic_api_key in a secret manager, or run 'v100 login --provider anthropic'", name, authEnv))
 					}
 					if anthropicKey != "" {
 						pingCtx, pingCancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/v100/cmd_admin_test.go
+++ b/cmd/v100/cmd_admin_test.go
@@ -60,3 +60,25 @@ func TestMemoryListCmdShowsAuditMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestConfigInitDoesNotWritePlaintextOAuthTemplate(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("HOME", root)
+
+	out, err := captureStdout(func() error {
+		cmd := configInitCmd()
+		return cmd.Execute()
+	})
+	if err != nil {
+		t.Fatalf("config init error = %v", err)
+	}
+
+	credsPath := filepath.Join(root, "v100", "oauth_credentials.json")
+	if _, err := os.Stat(credsPath); !os.IsNotExist(err) {
+		t.Fatalf("oauth credentials file exists or stat failed: %v", err)
+	}
+	if !strings.Contains(out, "OAuth client secrets not written to disk by default") {
+		t.Fatalf("config init output missing secure guidance:\n%s", out)
+	}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -39,6 +39,15 @@ const (
 	MiniMaxDefaultClientID = "78257093-7e40-4613-99e0-527b14b39113"
 )
 
+var (
+	codexTokenURL          = CodexTokenURL
+	geminiTokenURL         = GeminiTokenURL
+	miniMaxCodeURL         = MiniMaxCodeURL
+	miniMaxTokenURL        = MiniMaxTokenURL
+	miniMaxMinPollInterval = 2 * time.Second
+	openBrowser            = openBrowserOS
+)
+
 // OAuthCredentials holds client credentials loaded from disk.
 type OAuthCredentials struct {
 	CodexClientID      string `json:"codex_client_id"`
@@ -74,35 +83,134 @@ func LoadGeminiCredentials() (*OAuthCredentials, error) {
 // LoadMiniMaxCredentials reads and validates the MiniMax OAuth client config.
 // Falls back to MiniMaxDefaultClientID if missing from config.
 func LoadMiniMaxCredentials() (*OAuthCredentials, error) {
-	c, err := loadCredentials() // try loading with no required fields
-	if err != nil {
-		// If file is missing or unreadable, just use the default
-		return &OAuthCredentials{MiniMaxClientID: MiniMaxDefaultClientID}, nil
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if secret, err := resolveOAuthCredentialField(ctx, "minimax_client_id"); err == nil {
+		return &OAuthCredentials{MiniMaxClientID: secret.Value}, nil
 	}
-	if strings.TrimSpace(c.MiniMaxClientID) == "" {
-		c.MiniMaxClientID = MiniMaxDefaultClientID
+
+	c, found, err := loadPlaintextOAuthCredentials(DefaultCredentialsPath())
+	if err == nil && found {
+		warnPlaintextFallback("OAuth credentials", DefaultCredentialsPath())
+		if strings.TrimSpace(c.MiniMaxClientID) != "" {
+			return c, nil
+		}
 	}
-	return c, nil
+	return &OAuthCredentials{MiniMaxClientID: MiniMaxDefaultClientID}, nil
 }
 
 func loadCredentials(requiredFields ...string) (*OAuthCredentials, error) {
 	path := DefaultCredentialsPath()
+	c := &OAuthCredentials{}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var missing []string
+	for _, field := range requiredFields {
+		secret, err := resolveOAuthCredentialField(ctx, field)
+		if err == nil {
+			setCredentialValue(c, field, secret.Value)
+			continue
+		}
+		missing = append(missing, field)
+	}
+
+	if len(missing) > 0 {
+		fileCreds, found, err := loadPlaintextOAuthCredentials(path)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			warnPlaintextFallback("OAuth credentials", path)
+			for _, field := range missing {
+				if value := strings.TrimSpace(credentialValue(fileCreds, field)); value != "" {
+					setCredentialValue(c, field, value)
+				}
+			}
+		}
+	}
+
+	missing = missingCredentialFields(c, requiredFields...)
+	if len(missing) > 0 {
+		return nil, missingOAuthCredentialsError(missing, path)
+	}
+	return c, nil
+}
+
+type oauthCredentialSpec struct {
+	SecretKey string
+	EnvNames  []string
+	Set       func(*OAuthCredentials, string)
+	Get       func(*OAuthCredentials) string
+}
+
+var oauthCredentialSpecs = map[string]oauthCredentialSpec{
+	"codex_client_id": {
+		SecretKey: "oauth_codex_client_id",
+		EnvNames:  []string{"V100_CODEX_CLIENT_ID", "CODEX_CLIENT_ID", "OPENAI_CLIENT_ID", "OPENAI_OAUTH_CLIENT_ID"},
+		Set:       func(c *OAuthCredentials, value string) { c.CodexClientID = value },
+		Get:       func(c *OAuthCredentials) string { return c.CodexClientID },
+	},
+	"gemini_client_id": {
+		SecretKey: "oauth_gemini_client_id",
+		EnvNames:  []string{"V100_GEMINI_CLIENT_ID", "GEMINI_CLIENT_ID", "GOOGLE_OAUTH_CLIENT_ID"},
+		Set:       func(c *OAuthCredentials, value string) { c.GeminiClientID = value },
+		Get:       func(c *OAuthCredentials) string { return c.GeminiClientID },
+	},
+	"gemini_client_secret": {
+		SecretKey: "oauth_gemini_client_secret",
+		EnvNames:  []string{"V100_GEMINI_CLIENT_SECRET", "GEMINI_CLIENT_SECRET", "GOOGLE_OAUTH_CLIENT_SECRET"},
+		Set:       func(c *OAuthCredentials, value string) { c.GeminiClientSecret = value },
+		Get:       func(c *OAuthCredentials) string { return c.GeminiClientSecret },
+	},
+	"minimax_client_id": {
+		SecretKey: "oauth_minimax_client_id",
+		EnvNames:  []string{"V100_MINIMAX_CLIENT_ID", "MINIMAX_CLIENT_ID"},
+		Set:       func(c *OAuthCredentials, value string) { c.MiniMaxClientID = value },
+		Get:       func(c *OAuthCredentials) string { return c.MiniMaxClientID },
+	},
+}
+
+func resolveOAuthCredentialField(ctx context.Context, field string) (SecretValue, error) {
+	spec, ok := oauthCredentialSpecs[field]
+	if !ok {
+		return SecretValue{}, fmt.Errorf("%w: unknown OAuth credential field %s", ErrSecretUnavailable, field)
+	}
+	return ResolveSecret(ctx, spec.SecretKey, spec.EnvNames...)
+}
+
+func setCredentialValue(c *OAuthCredentials, field, value string) {
+	if spec, ok := oauthCredentialSpecs[field]; ok {
+		spec.Set(c, strings.TrimSpace(value))
+	}
+}
+
+func loadPlaintextOAuthCredentials(path string) (*OAuthCredentials, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if len(requiredFields) == 0 {
-			return &OAuthCredentials{}, nil
+		if os.IsNotExist(err) {
+			return nil, false, nil
 		}
-		return nil, fmt.Errorf("auth: read %s: %w\n  → create it with JSON keys: %s\n  → see: v100 doctor", path, err, strings.Join(requiredFields, ", "))
+		return nil, false, fmt.Errorf("auth: read plaintext OAuth credentials %s: %w", path, err)
 	}
 	var c OAuthCredentials
 	if err := json.Unmarshal(data, &c); err != nil {
-		return nil, fmt.Errorf("auth: parse %s: %w", path, err)
+		return nil, true, fmt.Errorf("auth: parse plaintext OAuth credentials %s: %w", path, err)
 	}
-	missing := missingCredentialFields(&c, requiredFields...)
-	if len(missing) > 0 {
-		return nil, fmt.Errorf("auth: missing %s in %s\n  → fill the required OAuth client values and retry\n  → see: v100 doctor", strings.Join(missing, ", "), path)
+	return &c, true, nil
+}
+
+func missingOAuthCredentialsError(missing []string, path string) error {
+	var hints []string
+	for _, field := range missing {
+		spec, ok := oauthCredentialSpecs[field]
+		if !ok {
+			hints = append(hints, field)
+			continue
+		}
+		hints = append(hints, fmt.Sprintf("%s (env: %s; secret: %s)", field, strings.Join(spec.EnvNames, "/"), spec.SecretKey))
 	}
-	return &c, nil
+	return fmt.Errorf("auth: missing OAuth credentials: %s\n  → set env vars, store secrets in 1Password/pass/system keyring, or use plaintext fallback at %s\n  → see: v100 doctor", strings.Join(hints, ", "), path)
 }
 
 func missingCredentialFields(c *OAuthCredentials, requiredFields ...string) []string {
@@ -116,18 +224,10 @@ func missingCredentialFields(c *OAuthCredentials, requiredFields ...string) []st
 }
 
 func credentialValue(c *OAuthCredentials, field string) string {
-	switch field {
-	case "codex_client_id":
-		return c.CodexClientID
-	case "gemini_client_id":
-		return c.GeminiClientID
-	case "gemini_client_secret":
-		return c.GeminiClientSecret
-	case "minimax_client_id":
-		return c.MiniMaxClientID
-	default:
-		return ""
+	if spec, ok := oauthCredentialSpecs[field]; ok {
+		return spec.Get(c)
 	}
+	return ""
 }
 
 // OAuthConfig describes parameters for a PKCE OAuth authorization code flow.
@@ -281,7 +381,7 @@ func Refresh(ctx context.Context, refreshToken string) (*Token, error) {
 		"refresh_token": {refreshToken},
 		"client_id":     {creds.CodexClientID},
 	}
-	return postTokenRequest(ctx, CodexTokenURL, form)
+	return postTokenRequest(ctx, codexTokenURL, form)
 }
 
 // RefreshGemini exchanges a refresh token for a new access token (Gemini).
@@ -296,7 +396,7 @@ func RefreshGemini(ctx context.Context, refreshToken string) (*Token, error) {
 		"client_id":     {creds.GeminiClientID},
 		"client_secret": {creds.GeminiClientSecret},
 	}
-	return postTokenRequest(ctx, GeminiTokenURL, form)
+	return postTokenRequest(ctx, geminiTokenURL, form)
 }
 
 // AccountIDFromJWT decodes the JWT payload and extracts chatgpt_account_id.
@@ -424,7 +524,7 @@ func LoginMiniMax(ctx context.Context) (*MiniMaxToken, error) {
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
 	}
-	codeReq, err := http.NewRequestWithContext(ctx, http.MethodPost, MiniMaxCodeURL, strings.NewReader(codeForm.Encode()))
+	codeReq, err := http.NewRequestWithContext(ctx, http.MethodPost, miniMaxCodeURL, strings.NewReader(codeForm.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("auth: build code request: %w", err)
 	}
@@ -465,8 +565,8 @@ func LoginMiniMax(ctx context.Context) (*MiniMaxToken, error) {
 
 	// Step 2: Poll for token (form-urlencoded)
 	interval := time.Duration(codeResult.Interval) * time.Millisecond
-	if interval < 2*time.Second {
-		interval = 2 * time.Second
+	if interval < miniMaxMinPollInterval {
+		interval = miniMaxMinPollInterval
 	}
 	// expired_in is a unix timestamp (seconds)
 	deadline := time.Unix(codeResult.ExpiredIn, 0)
@@ -484,7 +584,7 @@ func LoginMiniMax(ctx context.Context) (*MiniMaxToken, error) {
 			"user_code":     {codeResult.UserCode},
 			"code_verifier": {verifier},
 		}
-		tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, MiniMaxTokenURL, strings.NewReader(tokenForm.Encode()))
+		tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, miniMaxTokenURL, strings.NewReader(tokenForm.Encode()))
 		if err != nil {
 			return nil, fmt.Errorf("auth: build token request: %w", err)
 		}
@@ -536,7 +636,7 @@ func RefreshMiniMax(ctx context.Context, creds *OAuthCredentials, refreshToken s
 		"client_id":     {creds.MiniMaxClientID},
 		"refresh_token": {refreshToken},
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, MiniMaxTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, miniMaxTokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("auth: build refresh request: %w", err)
 	}
@@ -579,8 +679,8 @@ func RefreshMiniMax(ctx context.Context, creds *OAuthCredentials, refreshToken s
 	return t, nil
 }
 
-// openBrowser attempts to open the URL in the default browser.
-func openBrowser(u string) {
+// openBrowserOS attempts to open the URL in the default browser.
+func openBrowserOS(u string) {
 	var cmd string
 	var args []string
 	switch runtime.GOOS {

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,11 +1,20 @@
 package auth
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCredentialsTemplateIsValidJSON(t *testing.T) {
@@ -17,6 +26,7 @@ func TestCredentialsTemplateIsValidJSON(t *testing.T) {
 
 func TestLoadCodexCredentialsRequiresField(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
 	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
 		t.Fatalf("mkdir credentials dir: %v", err)
 	}
@@ -35,6 +45,7 @@ func TestLoadCodexCredentialsRequiresField(t *testing.T) {
 
 func TestLoadGeminiCredentialsRequiresFields(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
 	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
 		t.Fatalf("mkdir credentials dir: %v", err)
 	}
@@ -52,6 +63,8 @@ func TestLoadGeminiCredentialsRequiresFields(t *testing.T) {
 }
 
 func TestClaudeTokenSaveLoad(t *testing.T) {
+	withSecretManagers(t)
+	warnings := capturePlaintextWarnings(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "anthropic_auth.json")
 
@@ -69,6 +82,9 @@ func TestClaudeTokenSaveLoad(t *testing.T) {
 	}
 	if !loaded.Valid() {
 		t.Error("expected Valid() = true")
+	}
+	if !strings.Contains(warnings.String(), "plaintext Anthropic API key") {
+		t.Fatalf("expected plaintext warning, got %q", warnings.String())
 	}
 }
 
@@ -93,6 +109,7 @@ func TestClaudeTokenPathXDG(t *testing.T) {
 
 func TestLoadGeminiCredentialsSucceeds(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
 	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
 		t.Fatalf("mkdir credentials dir: %v", err)
 	}
@@ -107,4 +124,515 @@ func TestLoadGeminiCredentialsSucceeds(t *testing.T) {
 	if creds.GeminiClientID != "gid" || creds.GeminiClientSecret != "gsecret" {
 		t.Fatalf("unexpected credentials: %+v", creds)
 	}
+}
+
+func TestLoadCodexCredentialsUsesEnvBeforePlaintext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("V100_CODEX_CLIENT_ID", "env-cid")
+	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(DefaultCredentialsPath(), []byte(`{"codex_client_id":"file-cid"}`), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	creds, err := LoadCodexCredentials()
+	if err != nil {
+		t.Fatalf("LoadCodexCredentials() error = %v", err)
+	}
+	if creds.CodexClientID != "env-cid" {
+		t.Fatalf("codex client ID = %q, want env-cid", creds.CodexClientID)
+	}
+}
+
+func TestLoadGeminiCredentialsUsesSecretThenPlaintextFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t, fakeSecretManager{
+		name:   "test-secrets",
+		values: map[string]string{"oauth_gemini_client_id": "secret-gid"},
+	})
+	warnings := capturePlaintextWarnings(t)
+	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(DefaultCredentialsPath(), []byte(`{"gemini_client_secret":"file-secret"}`), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	creds, err := LoadGeminiCredentials()
+	if err != nil {
+		t.Fatalf("LoadGeminiCredentials() error = %v", err)
+	}
+	if creds.GeminiClientID != "secret-gid" || creds.GeminiClientSecret != "file-secret" {
+		t.Fatalf("unexpected credentials: %+v", creds)
+	}
+	if !strings.Contains(warnings.String(), "plaintext OAuth credentials") {
+		t.Fatalf("expected plaintext warning, got %q", warnings.String())
+	}
+}
+
+func TestLoadGeminiCredentialsMissingErrorNamesEnvSecretsAndFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
+
+	_, err := LoadGeminiCredentials()
+	if err == nil {
+		t.Fatal("LoadGeminiCredentials() returned nil error")
+	}
+	for _, want := range []string{"V100_GEMINI_CLIENT_ID", "oauth_gemini_client_secret", DefaultCredentialsPath()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q:\n%v", want, err)
+		}
+	}
+}
+
+func TestLoadMiniMaxCredentialsEnvAndDefault(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
+
+	creds, err := LoadMiniMaxCredentials()
+	if err != nil {
+		t.Fatalf("LoadMiniMaxCredentials() error = %v", err)
+	}
+	if creds.MiniMaxClientID != MiniMaxDefaultClientID {
+		t.Fatalf("default MiniMax client ID = %q", creds.MiniMaxClientID)
+	}
+
+	t.Setenv("V100_MINIMAX_CLIENT_ID", "env-minimax")
+	creds, err = LoadMiniMaxCredentials()
+	if err != nil {
+		t.Fatalf("LoadMiniMaxCredentials() with env error = %v", err)
+	}
+	if creds.MiniMaxClientID != "env-minimax" {
+		t.Fatalf("MiniMax client ID = %q, want env-minimax", creds.MiniMaxClientID)
+	}
+}
+
+func TestLoadMiniMaxCredentialsPlaintextFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withSecretManagers(t)
+	warnings := capturePlaintextWarnings(t)
+	if err := os.MkdirAll(filepath.Dir(DefaultCredentialsPath()), 0o755); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(DefaultCredentialsPath(), []byte(`{"minimax_client_id":"file-minimax"}`), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	creds, err := LoadMiniMaxCredentials()
+	if err != nil {
+		t.Fatalf("LoadMiniMaxCredentials() error = %v", err)
+	}
+	if creds.MiniMaxClientID != "file-minimax" {
+		t.Fatalf("MiniMax client ID = %q", creds.MiniMaxClientID)
+	}
+	if !strings.Contains(warnings.String(), "plaintext OAuth credentials") {
+		t.Fatalf("expected warning, got %q", warnings.String())
+	}
+}
+
+func TestOAuthCredentialHelpersUnknownFields(t *testing.T) {
+	if _, err := resolveOAuthCredentialField(context.Background(), "unknown"); err == nil {
+		t.Fatal("resolveOAuthCredentialField() returned nil error for unknown field")
+	}
+	c := &OAuthCredentials{}
+	setCredentialValue(c, "unknown", "value")
+	if got := credentialValue(c, "unknown"); got != "" {
+		t.Fatalf("unknown credential value = %q", got)
+	}
+	err := missingOAuthCredentialsError([]string{"unknown"}, "/tmp/fallback.json")
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("missing error = %v", err)
+	}
+}
+
+func TestOAuthConfigBuilders(t *testing.T) {
+	creds := &OAuthCredentials{
+		CodexClientID:      "codex-id",
+		GeminiClientID:     "gemini-id",
+		GeminiClientSecret: "gemini-secret",
+	}
+	codex := CodexOAuthConfig(creds)
+	if codex.ClientID != "codex-id" || codex.ClientSecret != "" || codex.TokenURL != CodexTokenURL {
+		t.Fatalf("unexpected codex config: %+v", codex)
+	}
+	gemini := GeminiOAuthConfig(creds)
+	if gemini.ClientID != "gemini-id" || gemini.ClientSecret != "gemini-secret" || gemini.ExtraParams["prompt"] != "consent" {
+		t.Fatalf("unexpected gemini config: %+v", gemini)
+	}
+}
+
+func TestPostTokenRequestResponses(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+				t.Fatalf("Content-Type = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","expires_in":3600}`))
+		}))
+		defer srv.Close()
+		tok, err := postTokenRequest(context.Background(), srv.URL, url.Values{"client_id": {"cid"}})
+		if err != nil {
+			t.Fatalf("postTokenRequest() error = %v", err)
+		}
+		if tok.Access != "access" || tok.Refresh != "refresh" || !tok.Valid() {
+			t.Fatalf("unexpected token: %+v", tok)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		code int
+		body string
+		want string
+	}{
+		{name: "http error", code: http.StatusUnauthorized, body: "denied", want: "HTTP 401"},
+		{name: "invalid json", code: http.StatusOK, body: "{", want: "parse token response"},
+		{name: "empty token", code: http.StatusOK, body: `{"expires_in":1}`, want: "empty access_token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			_, err := postTokenRequest(context.Background(), srv.URL, url.Values{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRefreshUsesEnvCredentialsAndTokenEndpoint(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("V100_CODEX_CLIENT_ID", "codex-env")
+	oldURL := codexTokenURL
+	defer func() { codexTokenURL = oldURL }()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := mustFormValue(t, r, "client_id"); got != "codex-env" {
+			t.Fatalf("client_id = %q", got)
+		}
+		if got := mustFormValue(t, r, "refresh_token"); got != "old-refresh" {
+			t.Fatalf("refresh_token = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	codexTokenURL = srv.URL
+
+	tok, err := Refresh(context.Background(), "old-refresh")
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if tok.Access != "new-access" || tok.Refresh != "new-refresh" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestRefreshGeminiUsesEnvCredentialsAndTokenEndpoint(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("V100_GEMINI_CLIENT_ID", "gemini-env")
+	t.Setenv("V100_GEMINI_CLIENT_SECRET", "gemini-secret")
+	oldURL := geminiTokenURL
+	defer func() { geminiTokenURL = oldURL }()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := mustFormValue(t, r, "client_secret"); got != "gemini-secret" {
+			t.Fatalf("client_secret = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"access_token":"gemini-access","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	geminiTokenURL = srv.URL
+
+	tok, err := RefreshGemini(context.Background(), "old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshGemini() error = %v", err)
+	}
+	if tok.Access != "gemini-access" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestLoginWithConfigCompletesCallbackAndTokenExchange(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := mustFormValue(t, r, "grant_type"); got != "authorization_code" {
+			t.Fatalf("grant_type = %q", got)
+		}
+		if got := mustFormValue(t, r, "code"); got != "callback-code" {
+			t.Fatalf("code = %q", got)
+		}
+		if mustFormValue(t, r, "code_verifier") == "" {
+			t.Fatal("empty code_verifier")
+		}
+		_, _ = w.Write([]byte(`{"access_token":"login-access","refresh_token":"login-refresh","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	addr := freeLocalAddr(t)
+	oldOpen := openBrowser
+	defer func() { openBrowser = oldOpen }()
+	openBrowser = func(authLink string) {
+		go func() {
+			u, err := url.Parse(authLink)
+			if err != nil {
+				return
+			}
+			callback := "http://" + addr + "/callback?state=" + url.QueryEscape(u.Query().Get("state")) + "&code=callback-code"
+			_, _ = http.Get(callback)
+		}()
+	}
+
+	tok, err := LoginWithConfig(context.Background(), OAuthConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		AuthURL:      "http://auth.local/authorize",
+		TokenURL:     tokenServer.URL,
+		RedirectURI:  "http://" + addr + "/callback",
+		Scopes:       "scope-a",
+		ExtraParams:  map[string]string{"access_type": "offline"},
+	})
+	if err != nil {
+		t.Fatalf("LoginWithConfig() error = %v", err)
+	}
+	if tok.Access != "login-access" || tok.Refresh != "login-refresh" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestMiniMaxLoginAndRefreshUseConfiguredSecrets(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("V100_MINIMAX_CLIENT_ID", "minimax-env")
+	oldCodeURL, oldTokenURL, oldMinInterval, oldOpen := miniMaxCodeURL, miniMaxTokenURL, miniMaxMinPollInterval, openBrowser
+	defer func() {
+		miniMaxCodeURL = oldCodeURL
+		miniMaxTokenURL = oldTokenURL
+		miniMaxMinPollInterval = oldMinInterval
+		openBrowser = oldOpen
+	}()
+	miniMaxMinPollInterval = time.Millisecond
+	openBrowser = func(string) {}
+
+	tokenCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/code":
+			state := mustFormValue(t, r, "state")
+			if got := mustFormValue(t, r, "client_id"); got != "minimax-env" {
+				t.Fatalf("client_id = %q", got)
+			}
+			_, _ = fmt.Fprintf(w, `{"user_code":"USER-CODE","verification_uri":"https://example.com/verify","expired_in":%d,"interval":1,"state":%q}`, time.Now().Add(time.Second).Unix(), state)
+		case "/token":
+			tokenCalls++
+			if got := mustFormValue(t, r, "client_id"); got != "minimax-env" {
+				t.Fatalf("client_id = %q", got)
+			}
+			switch mustFormValue(t, r, "grant_type") {
+			case MiniMaxGrantType:
+				_, _ = w.Write([]byte(`{"status":"success","access_token":"mini-access","refresh_token":"mini-refresh","expired_in":4102444800}`))
+			case "refresh_token":
+				_, _ = w.Write([]byte(`{"status":"success","access_token":"mini-refreshed","expired_in":4102444800}`))
+			default:
+				t.Fatalf("unexpected grant type")
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	miniMaxCodeURL = srv.URL + "/code"
+	miniMaxTokenURL = srv.URL + "/token"
+
+	tok, err := LoginMiniMax(context.Background())
+	if err != nil {
+		t.Fatalf("LoginMiniMax() error = %v", err)
+	}
+	if tok.Access != "mini-access" || tok.Refresh != "mini-refresh" {
+		t.Fatalf("unexpected minimax token: %+v", tok)
+	}
+
+	refreshed, err := RefreshMiniMax(context.Background(), &OAuthCredentials{MiniMaxClientID: "minimax-env"}, "old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshMiniMax() error = %v", err)
+	}
+	if refreshed.Access != "mini-refreshed" || refreshed.Refresh != "old-refresh" {
+		t.Fatalf("unexpected refreshed token: %+v", refreshed)
+	}
+	if tokenCalls < 2 {
+		t.Fatalf("token endpoint calls = %d, want at least 2", tokenCalls)
+	}
+}
+
+func TestMiniMaxLoginErrorBranches(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("V100_MINIMAX_CLIENT_ID", "minimax-env")
+	oldCodeURL, oldTokenURL, oldMinInterval, oldOpen := miniMaxCodeURL, miniMaxTokenURL, miniMaxMinPollInterval, openBrowser
+	defer func() {
+		miniMaxCodeURL = oldCodeURL
+		miniMaxTokenURL = oldTokenURL
+		miniMaxMinPollInterval = oldMinInterval
+		openBrowser = oldOpen
+	}()
+	miniMaxMinPollInterval = time.Millisecond
+	openBrowser = func(string) {}
+
+	for _, tc := range []struct {
+		name       string
+		codeBody   func(state string) string
+		codeStatus int
+		tokenBody  string
+		want       string
+	}{
+		{
+			name:       "code http error",
+			codeStatus: http.StatusBadGateway,
+			codeBody:   func(string) string { return "bad gateway" },
+			want:       "code endpoint HTTP 502",
+		},
+		{
+			name:       "code invalid json",
+			codeStatus: http.StatusOK,
+			codeBody:   func(string) string { return "{" },
+			want:       "parse code response",
+		},
+		{
+			name:       "code incomplete",
+			codeStatus: http.StatusOK,
+			codeBody:   func(state string) string { return fmt.Sprintf(`{"state":%q}`, state) },
+			want:       "incomplete code response",
+		},
+		{
+			name:       "state mismatch",
+			codeStatus: http.StatusOK,
+			codeBody: func(string) string {
+				return fmt.Sprintf(`{"user_code":"USER","verification_uri":"https://example.com","expired_in":%d,"interval":1,"state":"wrong"}`, time.Now().Add(time.Second).Unix())
+			},
+			want: "state mismatch",
+		},
+		{
+			name:       "token error",
+			codeStatus: http.StatusOK,
+			codeBody: func(state string) string {
+				return fmt.Sprintf(`{"user_code":"USER","verification_uri":"https://example.com","expired_in":%d,"interval":1,"state":%q}`, time.Now().Add(time.Second).Unix(), state)
+			},
+			tokenBody: `{"status":"error","message":"denied"}`,
+			want:      "MiniMax OAuth error",
+		},
+		{
+			name:       "token incomplete success",
+			codeStatus: http.StatusOK,
+			codeBody: func(state string) string {
+				return fmt.Sprintf(`{"user_code":"USER","verification_uri":"https://example.com","expired_in":%d,"interval":1,"state":%q}`, time.Now().Add(time.Second).Unix(), state)
+			},
+			tokenBody: `{"status":"success","access_token":"only-access"}`,
+			want:      "incomplete token payload",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/code":
+					w.WriteHeader(tc.codeStatus)
+					_, _ = w.Write([]byte(tc.codeBody(mustFormValue(t, r, "state"))))
+				case "/token":
+					_, _ = w.Write([]byte(tc.tokenBody))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			miniMaxCodeURL = srv.URL + "/code"
+			miniMaxTokenURL = srv.URL + "/token"
+
+			_, err := LoginMiniMax(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccountIDFromJWT(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"https://api.openai.com/auth":{"chatgpt_account_id":"acct-123"}}`))
+	if got := AccountIDFromJWT("header." + payload + ".sig"); got != "acct-123" {
+		t.Fatalf("AccountIDFromJWT() = %q", got)
+	}
+	for _, token := range []string{"bad", "a.@@@.c", "a." + base64.RawURLEncoding.EncodeToString([]byte(`{}`)) + ".c"} {
+		if got := AccountIDFromJWT(token); got != "" {
+			t.Fatalf("AccountIDFromJWT(%q) = %q, want empty", token, got)
+		}
+	}
+}
+
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge, err := GeneratePKCE()
+	if err != nil {
+		t.Fatalf("GeneratePKCE() error = %v", err)
+	}
+	if verifier == "" || challenge == "" || strings.Contains(verifier, "=") || strings.Contains(challenge, "=") {
+		t.Fatalf("invalid PKCE pair verifier=%q challenge=%q", verifier, challenge)
+	}
+	if verifier == challenge {
+		t.Fatal("verifier and challenge should differ")
+	}
+}
+
+func mustFormValue(t *testing.T, r *http.Request, key string) string {
+	t.Helper()
+	if err := r.ParseForm(); err != nil {
+		t.Fatalf("ParseForm: %v", err)
+	}
+	return r.Form.Get(key)
+}
+
+func freeLocalAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return addr
+}
+
+func withSecretManagers(t *testing.T, managers ...SecretManager) {
+	t.Helper()
+	old := defaultSecretManagers
+	defaultSecretManagers = func() []SecretManager { return managers }
+	t.Cleanup(func() { defaultSecretManagers = old })
+}
+
+func capturePlaintextWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := plaintextFallbackWarningWriter
+	plaintextFallbackWarningWriter = &buf
+	t.Cleanup(func() { plaintextFallbackWarningWriter = old })
+	return &buf
+}
+
+type fakeSecretManager struct {
+	name   string
+	values map[string]string
+	err    error
+}
+
+func (m fakeSecretManager) Name() string {
+	if m.name == "" {
+		return "fake"
+	}
+	return m.name
+}
+
+func (m fakeSecretManager) Get(_ context.Context, key string) (string, error) {
+	if value, ok := m.values[key]; ok {
+		return value, nil
+	}
+	if m.err != nil {
+		return "", m.err
+	}
+	return "", ErrSecretUnavailable
 }

--- a/internal/auth/secrets.go
+++ b/internal/auth/secrets.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+var ErrSecretUnavailable = errors.New("secret unavailable")
+
+type SecretValue struct {
+	Value  string
+	Source string
+}
+
+type SecretManager interface {
+	Name() string
+	Get(ctx context.Context, key string) (string, error)
+}
+
+var defaultSecretManagers = func() []SecretManager {
+	return []SecretManager{
+		OnePasswordManager{},
+		PassManager{},
+		SystemKeyringManager{},
+	}
+}
+
+var plaintextFallbackWarningWriter io.Writer = os.Stderr
+
+func warnPlaintextFallback(kind, path string) {
+	if plaintextFallbackWarningWriter == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(plaintextFallbackWarningWriter, "auth: warning: using plaintext %s from %s; prefer env vars or 1Password/pass/system keyring\n", kind, path)
+}
+
+var runSecretCommand = func(ctx context.Context, name string, args ...string) (string, error) {
+	if _, err := exec.LookPath(name); err != nil {
+		return "", fmt.Errorf("%w: %s not found", ErrSecretUnavailable, name)
+	}
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s: %w", ErrSecretUnavailable, name, err)
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", fmt.Errorf("%w: %s returned an empty value", ErrSecretUnavailable, name)
+	}
+	return value, nil
+}
+
+func ResolveSecret(ctx context.Context, key string, envNames ...string) (SecretValue, error) {
+	for _, name := range envNames {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return SecretValue{Value: value, Source: "env:" + name}, nil
+		}
+	}
+	return LookupSecret(ctx, key, defaultSecretManagers())
+}
+
+func LookupSecret(ctx context.Context, key string, managers []SecretManager) (SecretValue, error) {
+	var tried []string
+	for _, manager := range managers {
+		if manager == nil {
+			continue
+		}
+		value, err := manager.Get(ctx, key)
+		if err == nil && strings.TrimSpace(value) != "" {
+			return SecretValue{Value: strings.TrimSpace(value), Source: manager.Name()}, nil
+		}
+		tried = append(tried, manager.Name())
+	}
+	if len(tried) == 0 {
+		return SecretValue{}, fmt.Errorf("%w: no secret managers configured", ErrSecretUnavailable)
+	}
+	return SecretValue{}, fmt.Errorf("%w: %s not found via %s", ErrSecretUnavailable, key, strings.Join(tried, ", "))
+}
+
+type OnePasswordManager struct{}
+
+func (OnePasswordManager) Name() string { return "1password" }
+
+func (OnePasswordManager) Get(ctx context.Context, key string) (string, error) {
+	prefix := strings.TrimRight(strings.TrimSpace(os.Getenv("V100_1PASSWORD_PREFIX")), "/")
+	if prefix == "" {
+		prefix = "op://Private/v100"
+	}
+	return runSecretCommand(ctx, "op", "read", prefix+"/"+key)
+}
+
+type PassManager struct{}
+
+func (PassManager) Name() string { return "pass" }
+
+func (PassManager) Get(ctx context.Context, key string) (string, error) {
+	prefix := strings.Trim(strings.TrimSpace(os.Getenv("V100_PASS_PREFIX")), "/")
+	if prefix == "" {
+		prefix = "v100"
+	}
+	return runSecretCommand(ctx, "pass", "show", prefix+"/"+key)
+}
+
+type SystemKeyringManager struct{}
+
+func (SystemKeyringManager) Name() string { return "system-keyring" }
+
+func (SystemKeyringManager) Get(ctx context.Context, key string) (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return runSecretCommand(ctx, "security", "find-generic-password", "-s", "v100", "-a", key, "-w")
+	case "linux":
+		return runSecretCommand(ctx, "secret-tool", "lookup", "service", "v100", "key", key)
+	default:
+		return "", fmt.Errorf("%w: system keyring unsupported on %s", ErrSecretUnavailable, runtime.GOOS)
+	}
+}

--- a/internal/auth/secrets_test.go
+++ b/internal/auth/secrets_test.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveSecretChecksEnvFirst(t *testing.T) {
+	t.Setenv("V100_TEST_SECRET", " env-value ")
+	withSecretManagers(t, fakeSecretManager{
+		values: map[string]string{"test_secret": "manager-value"},
+	})
+
+	secret, err := ResolveSecret(context.Background(), "test_secret", "V100_TEST_SECRET")
+	if err != nil {
+		t.Fatalf("ResolveSecret() error = %v", err)
+	}
+	if secret.Value != "env-value" || secret.Source != "env:V100_TEST_SECRET" {
+		t.Fatalf("secret = %+v", secret)
+	}
+}
+
+func TestLookupSecretUsesManagersAndReportsFailure(t *testing.T) {
+	secret, err := LookupSecret(context.Background(), "wanted", []SecretManager{
+		fakeSecretManager{name: "empty", values: map[string]string{"other": "value"}},
+		fakeSecretManager{name: "hit", values: map[string]string{"wanted": "manager-value"}},
+	})
+	if err != nil {
+		t.Fatalf("LookupSecret() error = %v", err)
+	}
+	if secret.Value != "manager-value" || secret.Source != "hit" {
+		t.Fatalf("secret = %+v", secret)
+	}
+
+	_, err = LookupSecret(context.Background(), "missing", []SecretManager{
+		fakeSecretManager{name: "one", err: errors.New("nope")},
+		fakeSecretManager{name: "two", err: errors.New("nope")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "one, two") {
+		t.Fatalf("missing error = %v", err)
+	}
+
+	_, err = LookupSecret(context.Background(), "missing", nil)
+	if !errors.Is(err, ErrSecretUnavailable) || !strings.Contains(err.Error(), "no secret managers configured") {
+		t.Fatalf("nil manager error = %v", err)
+	}
+}
+
+func TestSecretManagerCommandAdapters(t *testing.T) {
+	oldRun := runSecretCommand
+	defer func() { runSecretCommand = oldRun }()
+	var calls []string
+	runSecretCommand = func(_ context.Context, name string, args ...string) (string, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return " command-value ", nil
+	}
+
+	t.Setenv("V100_1PASSWORD_PREFIX", "op://Vault/v100")
+	if (OnePasswordManager{}).Name() != "1password" {
+		t.Fatal("unexpected 1Password manager name")
+	}
+	value, err := OnePasswordManager{}.Get(context.Background(), "oauth_codex_client_id")
+	if err != nil || value != " command-value " {
+		t.Fatalf("1Password value=%q err=%v", value, err)
+	}
+	if calls[0] != "op read op://Vault/v100/oauth_codex_client_id" {
+		t.Fatalf("1Password call = %q", calls[0])
+	}
+
+	t.Setenv("V100_PASS_PREFIX", "team/v100")
+	if (PassManager{}).Name() != "pass" {
+		t.Fatal("unexpected pass manager name")
+	}
+	value, err = PassManager{}.Get(context.Background(), "oauth_gemini_client_secret")
+	if err != nil || value != " command-value " {
+		t.Fatalf("pass value=%q err=%v", value, err)
+	}
+	if calls[1] != "pass show team/v100/oauth_gemini_client_secret" {
+		t.Fatalf("pass call = %q", calls[1])
+	}
+
+	if (SystemKeyringManager{}).Name() != "system-keyring" {
+		t.Fatal("unexpected system keyring manager name")
+	}
+	_, _ = SystemKeyringManager{}.Get(context.Background(), "provider_anthropic_api_key")
+	switch runtime.GOOS {
+	case "darwin":
+		if !strings.HasPrefix(calls[2], "security find-generic-password -s v100 -a provider_anthropic_api_key -w") {
+			t.Fatalf("security call = %q", calls[2])
+		}
+	case "linux":
+		if calls[2] != "secret-tool lookup service v100 key provider_anthropic_api_key" {
+			t.Fatalf("secret-tool call = %q", calls[2])
+		}
+	default:
+		if len(calls) != 2 {
+			t.Fatalf("unexpected system keyring command on %s: %v", runtime.GOOS, calls)
+		}
+	}
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,10 +1,12 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -113,12 +115,31 @@ func DefaultClaudeTokenPath() string {
 	return filepath.Join(home, ".config", "v100", "anthropic_auth.json")
 }
 
-// LoadClaude reads a ClaudeToken from path.
+// LoadClaude reads a ClaudeToken from env, secrets manager, or a plaintext fallback file.
 func LoadClaude(path string) (*ClaudeToken, error) {
+	return LoadClaudeWithEnv(path, "ANTHROPIC_API_KEY")
+}
+
+// LoadClaudeWithEnv reads a ClaudeToken using authEnv before secrets manager and file fallback.
+func LoadClaudeWithEnv(path, authEnv string) (*ClaudeToken, error) {
+	if strings.TrimSpace(authEnv) == "" {
+		authEnv = "ANTHROPIC_API_KEY"
+	}
+	if value := strings.TrimSpace(os.Getenv(authEnv)); value != "" {
+		return &ClaudeToken{APIKey: value}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if secret, err := LookupSecret(ctx, "provider_anthropic_api_key", defaultSecretManagers()); err == nil {
+		return &ClaudeToken{APIKey: secret.Value}, nil
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("auth: read %s: %w", path, err)
+		return nil, fmt.Errorf("auth: read %s: %w\n  → set %s, store secret provider_anthropic_api_key in 1Password/pass/system keyring, or run 'v100 login --provider anthropic'", path, err, authEnv)
 	}
+	warnPlaintextFallback("Anthropic API key", path)
 	var t ClaudeToken
 	if err := json.Unmarshal(data, &t); err != nil {
 		return nil, fmt.Errorf("auth: parse %s: %w", path, err)

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTokenStoresSaveLoadAndValidity(t *testing.T) {
+	dir := t.TempDir()
+	future := time.Now().Add(time.Hour).UnixMilli()
+	past := time.Now().Add(-time.Hour).UnixMilli()
+
+	codexPath := filepath.Join(dir, "auth.json")
+	if err := Save(codexPath, &Token{Access: "access", Refresh: "refresh", ExpiresMS: future, AccountID: "acct"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	codex, err := Load(codexPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !codex.Valid() || codex.AccountID != "acct" {
+		t.Fatalf("unexpected codex token: %+v", codex)
+	}
+	if (&Token{Access: "access", ExpiresMS: past}).Valid() {
+		t.Fatal("expired codex token should be invalid")
+	}
+
+	geminiPath := filepath.Join(dir, "gemini_auth.json")
+	if err := SaveGemini(geminiPath, &GeminiToken{Access: "g-access", Refresh: "g-refresh", ExpiresMS: future, ProjectID: "project"}); err != nil {
+		t.Fatalf("SaveGemini() error = %v", err)
+	}
+	gemini, err := LoadGemini(geminiPath)
+	if err != nil {
+		t.Fatalf("LoadGemini() error = %v", err)
+	}
+	if !gemini.Valid() || gemini.ProjectID != "project" {
+		t.Fatalf("unexpected gemini token: %+v", gemini)
+	}
+	if (&GeminiToken{Access: "access", ExpiresMS: past}).Valid() {
+		t.Fatal("expired gemini token should be invalid")
+	}
+
+	minimaxPath := filepath.Join(dir, "minimax_auth.json")
+	if err := SaveMiniMax(minimaxPath, &MiniMaxToken{Access: "m-access", Refresh: "m-refresh", ExpiresMS: future}); err != nil {
+		t.Fatalf("SaveMiniMax() error = %v", err)
+	}
+	minimax, err := LoadMiniMax(minimaxPath)
+	if err != nil {
+		t.Fatalf("LoadMiniMax() error = %v", err)
+	}
+	if !minimax.Valid() || minimax.Refresh != "m-refresh" {
+		t.Fatalf("unexpected minimax token: %+v", minimax)
+	}
+	if (&MiniMaxToken{Access: "access", ExpiresMS: past}).Valid() {
+		t.Fatal("expired minimax token should be invalid")
+	}
+}
+
+func TestDefaultTokenPathsRespectXDGConfigHome(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/v100-xdg")
+	want := map[string]string{
+		DefaultTokenPath():        "/tmp/v100-xdg/v100/auth.json",
+		DefaultGeminiTokenPath():  "/tmp/v100-xdg/v100/gemini_auth.json",
+		DefaultClaudeTokenPath():  "/tmp/v100-xdg/v100/anthropic_auth.json",
+		DefaultMiniMaxTokenPath(): "/tmp/v100-xdg/v100/minimax_auth.json",
+	}
+	for got, expected := range want {
+		if got != expected {
+			t.Fatalf("path = %q, want %q", got, expected)
+		}
+	}
+}
+
+func TestDefaultTokenPathsUseHomeFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/tmp/v100-home")
+	for _, got := range []string{
+		DefaultTokenPath(),
+		DefaultGeminiTokenPath(),
+		DefaultClaudeTokenPath(),
+		DefaultMiniMaxTokenPath(),
+		DefaultCredentialsPath(),
+	} {
+		if !strings.HasPrefix(got, "/tmp/v100-home/.config/v100/") {
+			t.Fatalf("path = %q, want home fallback", got)
+		}
+	}
+}
+
+func TestLoadClaudeEnvSecretAndPlaintextOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "anthropic_auth.json")
+	if err := os.WriteFile(path, []byte(`{"api_key":"file-key"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "env-key")
+	withSecretManagers(t, fakeSecretManager{values: map[string]string{"provider_anthropic_api_key": "secret-key"}})
+	token, err := LoadClaude(path)
+	if err != nil {
+		t.Fatalf("LoadClaude() env error = %v", err)
+	}
+	if token.APIKey != "env-key" {
+		t.Fatalf("env API key = %q", token.APIKey)
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	token, err = LoadClaude(path)
+	if err != nil {
+		t.Fatalf("LoadClaude() secret error = %v", err)
+	}
+	if token.APIKey != "secret-key" {
+		t.Fatalf("secret API key = %q", token.APIKey)
+	}
+
+	withSecretManagers(t)
+	warnings := capturePlaintextWarnings(t)
+	token, err = LoadClaude(path)
+	if err != nil {
+		t.Fatalf("LoadClaude() plaintext error = %v", err)
+	}
+	if token.APIKey != "file-key" {
+		t.Fatalf("file API key = %q", token.APIKey)
+	}
+	if !strings.Contains(warnings.String(), "plaintext Anthropic API key") {
+		t.Fatalf("expected warning, got %q", warnings.String())
+	}
+}

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
+
+	"github.com/tripledoublev/v100/internal/auth"
 )
 
 const (
@@ -27,9 +28,8 @@ type AnthropicProvider struct {
 	client       *http.Client
 }
 
-// NewAnthropicProvider creates a provider. It checks for a stored API key at
-// storedKeyPath first (empty string uses the default path), then falls back to
-// the environment variable authEnv.
+// NewAnthropicProvider creates a provider using env, secrets manager, or a
+// plaintext fallback API key.
 func NewAnthropicProvider(authEnv, defaultModel string) (*AnthropicProvider, error) {
 	if authEnv == "" {
 		authEnv = "ANTHROPIC_API_KEY"
@@ -53,26 +53,11 @@ func NewAnthropicProvider(authEnv, defaultModel string) (*AnthropicProvider, err
 
 // resolveAnthropicKey returns the API key from the stored auth file or env var.
 func resolveAnthropicKey(authEnv string) string {
-	// 1. Check stored auth file.
-	path := defaultClaudeTokenPath()
-	if data, err := os.ReadFile(path); err == nil {
-		var stored struct {
-			APIKey string `json:"api_key"`
-		}
-		if json.Unmarshal(data, &stored) == nil && stored.APIKey != "" {
-			return stored.APIKey
-		}
+	token, err := auth.LoadClaudeWithEnv(auth.DefaultClaudeTokenPath(), authEnv)
+	if err != nil || token == nil {
+		return ""
 	}
-	// 2. Fall back to env var.
-	return os.Getenv(authEnv)
-}
-
-func defaultClaudeTokenPath() string {
-	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return xdg + "/v100/anthropic_auth.json"
-	}
-	home, _ := os.UserHomeDir()
-	return home + "/.config/v100/anthropic_auth.json"
+	return strings.TrimSpace(token.APIKey)
 }
 
 func (p *AnthropicProvider) Name() string { return "anthropic" }

--- a/internal/providers/anthropic_test.go
+++ b/internal/providers/anthropic_test.go
@@ -353,7 +353,7 @@ func TestAnthropicParseResponse(t *testing.T) {
 	}
 }
 
-func TestResolveAnthropicKeyFromFile(t *testing.T) {
+func TestResolveAnthropicKeyPrefersEnvOverFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
@@ -365,12 +365,30 @@ func TestResolveAnthropicKeyFromFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(authDir, "anthropic_auth.json"), []byte(`{"api_key":"sk-ant-stored"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// Also set env var — stored key should take priority
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-envvar")
 
 	key := resolveAnthropicKey("ANTHROPIC_API_KEY")
+	if key != "sk-ant-envvar" {
+		t.Errorf("expected env key, got %q", key)
+	}
+}
+
+func TestResolveAnthropicKeyFromFileFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("PATH", "")
+
+	authDir := filepath.Join(dir, "v100")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "anthropic_auth.json"), []byte(`{"api_key":"sk-ant-stored"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	key := resolveAnthropicKey("ANTHROPIC_API_KEY")
 	if key != "sk-ant-stored" {
-		t.Errorf("expected stored key, got %q", key)
+		t.Errorf("expected file fallback key, got %q", key)
 	}
 }
 
@@ -389,6 +407,7 @@ func TestResolveAnthropicKeyEmpty(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("PATH", "")
 
 	key := resolveAnthropicKey("ANTHROPIC_API_KEY")
 	if key != "" {


### PR DESCRIPTION
## Summary
- add an auth secret manager abstraction for env-first resolution with 1Password, pass, and system keyring fallbacks
- load OAuth client credentials from env/secrets before the legacy plaintext fallback, and warn when plaintext files are used
- make Anthropic API key loading env-first, then secrets manager, then plaintext fallback
- stop `v100 config init` from writing `oauth_credentials.json` by default and add secure setup guidance
- document the secrets model in `SECURITY.md`

Fixes #223

## Verification
- ./scripts/lint.sh
- env GOCACHE=/tmp/v100-issue223-gocache go test -coverprofile=/tmp/v100-issue223-auth.cover ./internal/auth (77.8% package coverage; 79.7% by go tool cover total)
- env GOCACHE=/tmp/v100-issue223-gocache go test ./internal/auth ./internal/providers ./cmd/v100
- env GOCACHE=/tmp/v100-issue223-gocache go test ./...
- env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue223 GIT_WORK_TREE=/tmp/v100-issue223 GOCACHE=/tmp/v100-issue223-gocache go build ./...

Note: auth tests use local httptest sockets, so the coverage/touched/full test runs were run outside the sandbox.
