### PR TITLE
fix: bound vector memory store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Do not commit secrets from `.env`, provider credentials, traces, or local run ar
 Workspace blackboard vectors live in `blackboard.vectors.json`. New memory
 items receive a default 7-day TTL unless an explicit `expires_at` is provided.
 The vector store prunes expired entries on load, search, item listing, and
-background compaction. It also rejects duplicate embeddings, evicts oldest
+background compaction started for agent steps. It also rejects duplicate embeddings, evicts oldest
 items beyond the per-scope cap, and trims oldest records when the JSON store
 exceeds the configured size cap. Use `VectorStore.WithOptions` in tests or
 specialized stores when a different TTL, per-scope item cap, or store-size cap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,14 @@ Recent history uses short imperative summaries, often with `feat:` or `fix:` pre
 ## Security & Configuration Tips
 
 Do not commit secrets from `.env`, provider credentials, traces, or local run artifacts. Treat sandbox, network-tier, and dangerous-tool policy changes as high risk and cover them with tests.
+
+## Vector Store Lifecycle
+
+Workspace blackboard vectors live in `blackboard.vectors.json`. New memory
+items receive a default 7-day TTL unless an explicit `expires_at` is provided.
+The vector store prunes expired entries on load, search, item listing, and
+background compaction. It also rejects duplicate embeddings, evicts oldest
+items beyond the per-scope cap, and trims oldest records when the JSON store
+exceeds the configured size cap. Use `VectorStore.WithOptions` in tests or
+specialized stores when a different TTL, per-scope item cap, or store-size cap
+is required.

--- a/cmd/v100/cmd_admin_test.go
+++ b/cmd/v100/cmd_admin_test.go
@@ -35,7 +35,7 @@ func TestMemoryListCmdShowsAuditMetadata(t *testing.T) {
 		Metadata: memory.Metadata{
 			Tags: map[string]string{"scope": "workspace", "origin": "tool:blackboard_store", "confidence": "stored"},
 		},
-		TS: time.Date(2026, 3, 24, 4, 0, 0, 0, time.UTC),
+		TS: time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/loop.go
+++ b/internal/core/loop.go
@@ -251,6 +251,8 @@ func (l *Loop) StepWithImages(ctx context.Context, userInput string, images []pr
 		}
 	}
 	l.pendingUserImages = append([]providers.ImageAttachment(nil), images...)
+	stopMemoryCompaction := l.startMemoryCompaction(ctx)
+	defer stopMemoryCompaction()
 
 	solver := l.Solver
 	if solver == nil {

--- a/internal/core/memory_compress_test.go
+++ b/internal/core/memory_compress_test.go
@@ -877,6 +877,62 @@ func TestMemoryRetrievalIncludesWorkspaceVectorEntries(t *testing.T) {
 	t.Fatal("expected workspace vector memory in provider request")
 }
 
+func TestLoopCompactsWorkspaceMemoryDuringStep(t *testing.T) {
+	dir := t.TempDir()
+	past := time.Now().Add(-time.Hour)
+	store := memory.NewWorkspaceVectorStore(dir).WithOptions(memory.VectorStoreOptions{
+		DefaultTTL:       -1,
+		MaxItemsPerScope: -1,
+		MaxStoreBytes:    -1,
+	})
+	if err := store.Add(memory.MemoryItem{
+		ID:        "expired",
+		Content:   "expired memory",
+		ExpiresAt: &past,
+		TS:        time.Now().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &capturingProvider{
+		responses: []providers.CompleteResponse{{AssistantText: "ok"}},
+	}
+	tracePath := filepath.Join(dir, "trace.jsonl")
+	trace, err := core.OpenTrace(tracePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = trace.Close() }()
+
+	pol := policy.Default()
+	pol.MemoryMode = "auto"
+	loop := &core.Loop{
+		Run:       &core.Run{ID: "t", Dir: dir, TraceFile: tracePath},
+		Provider:  prov,
+		Tools:     tools.NewRegistry(nil),
+		Policy:    pol,
+		Trace:     trace,
+		Budget:    core.NewBudgetTracker(&core.Budget{MaxSteps: 10, MaxTokens: 100_000}),
+		ConfirmFn: func(_, _ string) bool { return true },
+	}
+
+	if err := loop.Step(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "blackboard.vectors.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted []memory.MemoryItem
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if len(persisted) != 0 {
+		t.Fatalf("expired memories persisted after step compaction: %+v", persisted)
+	}
+}
+
 func TestMemorySkippedInAutoModeWhenTurnLooksUnrelated(t *testing.T) {
 	dir := t.TempDir()
 	memPath := filepath.Join(dir, "MEMORY.md")

--- a/internal/core/memory_compress_test.go
+++ b/internal/core/memory_compress_test.go
@@ -609,8 +609,8 @@ func TestBulkCompressionSanitizesMalformedGLMPayloads(t *testing.T) {
 	}
 	for _, req := range compressProv.requests {
 		for _, msg := range req.Messages {
-		if strings.Contains(msg.Content, "</arg_") || strings.Contains(msg.Content, "<arg_") {
-			t.Fatalf("compression request still contained malformed tool markers: %q", msg.Content)
+			if strings.Contains(msg.Content, "</arg_") || strings.Contains(msg.Content, "<arg_") {
+				t.Fatalf("compression request still contained malformed tool markers: %q", msg.Content)
 			}
 		}
 	}
@@ -829,7 +829,7 @@ func TestMemoryRetrievalIncludesWorkspaceVectorEntries(t *testing.T) {
 		Metadata: memory.Metadata{
 			Tags: map[string]string{"scope": "workspace", "topic": "replay"},
 		},
-		TS: time.Date(2026, 3, 24, 3, 0, 0, 0, time.UTC),
+		TS: time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/core/memory_reference.go
+++ b/internal/core/memory_reference.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,6 +85,22 @@ func (l *Loop) memoryWorkspaceDir() string {
 		return l.Run.Dir
 	}
 	return ""
+}
+
+func (l *Loop) startMemoryCompaction(ctx context.Context) func() {
+	if l.Policy == nil || strings.EqualFold(strings.TrimSpace(l.Policy.MemoryMode), "off") {
+		return func() {}
+	}
+	workspaceDir := l.memoryWorkspaceDir()
+	if workspaceDir == "" {
+		return func() {}
+	}
+	compactionCtx, cancel := context.WithCancel(ctx)
+	done := memory.NewWorkspaceVectorStore(workspaceDir).StartCompaction(compactionCtx, memory.DefaultVectorStoreCompactionEvery)
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func (l *Loop) memoryAlwaysEnabled() bool {

--- a/internal/memory/review_test.go
+++ b/internal/memory/review_test.go
@@ -21,7 +21,7 @@ func TestLoadAuditEntriesIncludesManualAndWorkspaceMemory(t *testing.T) {
 		Metadata: Metadata{
 			Tags: map[string]string{"scope": "workspace", "origin": "manual-promote", "confidence": "high"},
 		},
-		TS: time.Date(2026, 3, 24, 4, 0, 0, 0, time.UTC),
+		TS: time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -1,7 +1,9 @@
 package memory
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -19,6 +21,31 @@ type MemoryItem struct {
 	Metadata  Metadata   `json:"metadata"`
 	TS        time.Time  `json:"ts"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+const (
+	DefaultVectorStoreTTL              = 7 * 24 * time.Hour
+	DefaultVectorStoreMaxItemsPerScope = 1000
+	DefaultVectorStoreMaxBytes         = 4 * 1024 * 1024
+	duplicateEmbeddingThreshold        = 0.999999
+)
+
+var ErrDuplicateEmbedding = errors.New("duplicate memory embedding")
+
+// VectorStoreOptions bounds a vector store's lifecycle and disk footprint.
+type VectorStoreOptions struct {
+	DefaultTTL       time.Duration `json:"default_ttl"`
+	MaxItemsPerScope int           `json:"max_items_per_scope"`
+	MaxStoreBytes    int64         `json:"max_store_bytes"`
+}
+
+// DefaultVectorStoreOptions returns the bounded lifecycle defaults.
+func DefaultVectorStoreOptions() VectorStoreOptions {
+	return VectorStoreOptions{
+		DefaultTTL:       DefaultVectorStoreTTL,
+		MaxItemsPerScope: DefaultVectorStoreMaxItemsPerScope,
+		MaxStoreBytes:    DefaultVectorStoreMaxBytes,
+	}
 }
 
 // Metadata holds extra context for a memory record.
@@ -39,6 +66,7 @@ type VectorStore struct {
 	runID   string
 	runPath string
 	items   []MemoryItem
+	opts    VectorStoreOptions
 }
 
 // NewVectorStore initializes a store for a specific run.
@@ -47,6 +75,7 @@ func NewVectorStore(runID string) *VectorStore {
 		runID:   runID,
 		runPath: filepath.Join("runs", runID, "blackboard.vectors.json"),
 		items:   []MemoryItem{},
+		opts:    DefaultVectorStoreOptions(),
 	}
 }
 
@@ -55,6 +84,7 @@ func NewWorkspaceVectorStore(workspaceDir string) *VectorStore {
 	return &VectorStore{
 		runPath: filepath.Join(workspaceDir, "blackboard.vectors.json"),
 		items:   []MemoryItem{},
+		opts:    DefaultVectorStoreOptions(),
 	}
 }
 
@@ -64,7 +94,15 @@ func NewNamedVectorStore(workspaceDir, name string) *VectorStore {
 	return &VectorStore{
 		runPath: filepath.Join(workspaceDir, name+".vectors.json"),
 		items:   []MemoryItem{},
+		opts:    DefaultVectorStoreOptions(),
 	}
+}
+
+// WithOptions returns a copy of the store using normalized lifecycle options.
+func (s *VectorStore) WithOptions(opts VectorStoreOptions) *VectorStore {
+	cp := *s
+	cp.opts = normalizeOptions(opts)
+	return &cp
 }
 
 // Load reads existing vectors from disk.
@@ -76,11 +114,16 @@ func (s *VectorStore) Load() error {
 		}
 		return err
 	}
-	return json.Unmarshal(data, &s.items)
+	if err := json.Unmarshal(data, &s.items); err != nil {
+		return err
+	}
+	s.Prune()
+	return nil
 }
 
 // Save persists the current state to disk.
 func (s *VectorStore) Save() error {
+	s.enforceLimits()
 	if err := os.MkdirAll(filepath.Dir(s.runPath), 0755); err != nil {
 		return err
 	}
@@ -94,7 +137,11 @@ func (s *VectorStore) Save() error {
 // HasTag reports whether any item in the store has the given tag key=value pair.
 // Used for deduplication at indexing time.
 func (s *VectorStore) HasTag(key, value string) bool {
+	now := time.Now()
 	for _, item := range s.items {
+		if item.Expired(now) {
+			continue
+		}
 		if item.Metadata.Tags != nil && item.Metadata.Tags[key] == value {
 			return true
 		}
@@ -104,7 +151,13 @@ func (s *VectorStore) HasTag(key, value string) bool {
 
 // Add appends a new item and saves.
 func (s *VectorStore) Add(item MemoryItem) error {
+	s.Prune()
+	item = s.prepareItem(item)
+	if duplicate := s.duplicateEmbedding(item); duplicate != nil {
+		return fmt.Errorf("%w: %s", ErrDuplicateEmbedding, duplicate.ID)
+	}
 	s.items = append(s.items, item)
+	s.enforceLimits()
 	return s.Save()
 }
 
@@ -115,6 +168,7 @@ func (m MemoryItem) Expired(now time.Time) bool {
 
 // Items returns a copy of the currently loaded items.
 func (s *VectorStore) Items() []MemoryItem {
+	s.Prune()
 	now := time.Now()
 	out := make([]MemoryItem, 0, len(s.items))
 	for _, item := range s.items {
@@ -163,12 +217,35 @@ func (s *VectorStore) Prune() int {
 	return removed
 }
 
+// StartCompaction prunes expired items on a background interval until ctx ends.
+func (s *VectorStore) StartCompaction(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.Prune()
+			}
+		}
+	}()
+	return done
+}
+
 // Search returns top-k items sorted by cosine similarity to the query embedding.
 func (s *VectorStore) Search(query []float32, k int) []SearchResult {
 	if k <= 0 || len(s.items) == 0 {
 		return nil
 	}
 
+	s.Prune()
 	results := make([]SearchResult, 0, len(s.items))
 	now := time.Now()
 	for _, item := range s.items {
@@ -187,6 +264,136 @@ func (s *VectorStore) Search(query []float32, k int) []SearchResult {
 		results = results[:k]
 	}
 	return results
+}
+
+func (s *VectorStore) prepareItem(item MemoryItem) MemoryItem {
+	if item.TS.IsZero() {
+		item.TS = time.Now().UTC()
+	}
+	if item.ExpiresAt == nil {
+		opts := s.options()
+		if opts.DefaultTTL > 0 {
+			expires := item.TS.Add(opts.DefaultTTL)
+			item.ExpiresAt = &expires
+		}
+	}
+	return item
+}
+
+func (s *VectorStore) duplicateEmbedding(item MemoryItem) *MemoryItem {
+	if len(item.Embedding) == 0 {
+		return nil
+	}
+	now := time.Now()
+	for i := range s.items {
+		existing := &s.items[i]
+		if existing.Expired(now) || len(existing.Embedding) == 0 {
+			continue
+		}
+		if len(existing.Embedding) != len(item.Embedding) {
+			continue
+		}
+		if cosineSimilarity(existing.Embedding, item.Embedding) >= duplicateEmbeddingThreshold {
+			return existing
+		}
+	}
+	return nil
+}
+
+func (s *VectorStore) enforceLimits() {
+	s.Prune()
+	opts := s.options()
+	if opts.MaxItemsPerScope > 0 {
+		s.evictByScope(opts.MaxItemsPerScope)
+	}
+	if opts.MaxStoreBytes > 0 {
+		s.evictBySize(opts.MaxStoreBytes)
+	}
+}
+
+func (s *VectorStore) evictByScope(maxItems int) {
+	byScope := make(map[string][]int)
+	for i, item := range s.items {
+		byScope[item.Scope()] = append(byScope[item.Scope()], i)
+	}
+	remove := make(map[int]struct{})
+	for _, indexes := range byScope {
+		if len(indexes) <= maxItems {
+			continue
+		}
+		sort.Slice(indexes, func(i, j int) bool {
+			return s.items[indexes[i]].TS.Before(s.items[indexes[j]].TS)
+		})
+		for _, idx := range indexes[:len(indexes)-maxItems] {
+			remove[idx] = struct{}{}
+		}
+	}
+	if len(remove) == 0 {
+		return
+	}
+	s.removeIndexes(remove)
+}
+
+func (s *VectorStore) evictBySize(maxBytes int64) {
+	for int64(s.encodedSize()) > maxBytes && len(s.items) > 0 {
+		oldest := 0
+		for i := 1; i < len(s.items); i++ {
+			if s.items[i].TS.Before(s.items[oldest].TS) {
+				oldest = i
+			}
+		}
+		s.removeIndexes(map[int]struct{}{oldest: {}})
+	}
+}
+
+func (s *VectorStore) encodedSize() int {
+	data, err := json.Marshal(s.items)
+	if err != nil {
+		return 0
+	}
+	return len(data)
+}
+
+func (s *VectorStore) removeIndexes(remove map[int]struct{}) {
+	kept := s.items[:0]
+	for i, item := range s.items {
+		if _, ok := remove[i]; ok {
+			continue
+		}
+		kept = append(kept, item)
+	}
+	s.items = append([]MemoryItem(nil), kept...)
+}
+
+func (s *VectorStore) options() VectorStoreOptions {
+	return normalizeOptions(s.opts)
+}
+
+func normalizeOptions(opts VectorStoreOptions) VectorStoreOptions {
+	defaults := DefaultVectorStoreOptions()
+	if opts.DefaultTTL == 0 {
+		opts.DefaultTTL = defaults.DefaultTTL
+	}
+	if opts.MaxItemsPerScope == 0 {
+		opts.MaxItemsPerScope = defaults.MaxItemsPerScope
+	}
+	if opts.MaxStoreBytes == 0 {
+		opts.MaxStoreBytes = defaults.MaxStoreBytes
+	}
+	return opts
+}
+
+// Scope returns the item's eviction scope.
+func (m MemoryItem) Scope() string {
+	if m.Metadata.Tags != nil {
+		if scope := m.Metadata.Tags["scope"]; scope != "" {
+			return scope
+		}
+	}
+	if m.Category != "" {
+		return m.Category
+	}
+	return "default"
 }
 
 func cosineSimilarity(a, b []float32) float32 {

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -27,10 +28,13 @@ const (
 	DefaultVectorStoreTTL              = 7 * 24 * time.Hour
 	DefaultVectorStoreMaxItemsPerScope = 1000
 	DefaultVectorStoreMaxBytes         = 4 * 1024 * 1024
+	DefaultVectorStoreCompactionEvery  = time.Minute
 	duplicateEmbeddingThreshold        = 0.999999
 )
 
 var ErrDuplicateEmbedding = errors.New("duplicate memory embedding")
+
+var vectorStoreFileLocks sync.Map
 
 // VectorStoreOptions bounds a vector store's lifecycle and disk footprint.
 type VectorStoreOptions struct {
@@ -63,6 +67,7 @@ type SearchResult struct {
 
 // VectorStore is a simple, local vector database for agent runs.
 type VectorStore struct {
+	mu      sync.RWMutex
 	runID   string
 	runPath string
 	items   []MemoryItem
@@ -100,13 +105,27 @@ func NewNamedVectorStore(workspaceDir, name string) *VectorStore {
 
 // WithOptions returns a copy of the store using normalized lifecycle options.
 func (s *VectorStore) WithOptions(opts VectorStoreOptions) *VectorStore {
-	cp := *s
-	cp.opts = normalizeOptions(opts)
-	return &cp
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return &VectorStore{
+		runID:   s.runID,
+		runPath: s.runPath,
+		items:   append([]MemoryItem(nil), s.items...),
+		opts:    normalizeOptions(opts),
+	}
 }
 
 // Load reads existing vectors from disk.
 func (s *VectorStore) Load() error {
+	unlock := s.lockFile()
+	defer unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadLocked()
+}
+
+func (s *VectorStore) loadLocked() error {
 	data, err := os.ReadFile(s.runPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -117,13 +136,24 @@ func (s *VectorStore) Load() error {
 	if err := json.Unmarshal(data, &s.items); err != nil {
 		return err
 	}
-	s.Prune()
+	if s.pruneExpiredLocked(time.Now()) > 0 {
+		return s.saveLocked()
+	}
 	return nil
 }
 
 // Save persists the current state to disk.
 func (s *VectorStore) Save() error {
-	s.enforceLimits()
+	unlock := s.lockFile()
+	defer unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enforceLimitsLocked()
+	return s.saveLocked()
+}
+
+func (s *VectorStore) saveLocked() error {
 	if err := os.MkdirAll(filepath.Dir(s.runPath), 0755); err != nil {
 		return err
 	}
@@ -137,6 +167,10 @@ func (s *VectorStore) Save() error {
 // HasTag reports whether any item in the store has the given tag key=value pair.
 // Used for deduplication at indexing time.
 func (s *VectorStore) HasTag(key, value string) bool {
+	s.Prune()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	now := time.Now()
 	for _, item := range s.items {
 		if item.Expired(now) {
@@ -151,14 +185,22 @@ func (s *VectorStore) HasTag(key, value string) bool {
 
 // Add appends a new item and saves.
 func (s *VectorStore) Add(item MemoryItem) error {
-	s.Prune()
+	unlock := s.lockFile()
+	defer unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return err
+	}
+	s.pruneExpiredLocked(time.Now())
 	item = s.prepareItem(item)
 	if duplicate := s.duplicateEmbedding(item); duplicate != nil {
 		return fmt.Errorf("%w: %s", ErrDuplicateEmbedding, duplicate.ID)
 	}
 	s.items = append(s.items, item)
-	s.enforceLimits()
-	return s.Save()
+	s.enforceLimitsLocked()
+	return s.saveLocked()
 }
 
 // Expired reports whether the item should no longer be surfaced.
@@ -169,6 +211,9 @@ func (m MemoryItem) Expired(now time.Time) bool {
 // Items returns a copy of the currently loaded items.
 func (s *VectorStore) Items() []MemoryItem {
 	s.Prune()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	now := time.Now()
 	out := make([]MemoryItem, 0, len(s.items))
 	for _, item := range s.items {
@@ -182,6 +227,14 @@ func (s *VectorStore) Items() []MemoryItem {
 
 // Remove deletes an item by ID and saves.
 func (s *VectorStore) Remove(id string) error {
+	unlock := s.lockFile()
+	defer unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return err
+	}
 	kept := s.items[:0]
 	found := false
 	for _, item := range s.items {
@@ -195,12 +248,26 @@ func (s *VectorStore) Remove(id string) error {
 		return fmt.Errorf("memory entry %q not found", id)
 	}
 	s.items = append([]MemoryItem(nil), kept...)
-	return s.Save()
+	s.enforceLimitsLocked()
+	return s.saveLocked()
 }
 
 // Prune removes expired items and saves if any were removed.
 func (s *VectorStore) Prune() int {
-	now := time.Now()
+	unlock := s.lockFile()
+	defer unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.loadLocked()
+	removed := s.pruneExpiredLocked(time.Now())
+	if removed > 0 {
+		_ = s.saveLocked()
+	}
+	return removed
+}
+
+func (s *VectorStore) pruneExpiredLocked(now time.Time) int {
 	kept := s.items[:0]
 	removed := 0
 	for _, item := range s.items {
@@ -212,7 +279,6 @@ func (s *VectorStore) Prune() int {
 	}
 	if removed > 0 {
 		s.items = append([]MemoryItem(nil), kept...)
-		_ = s.Save()
 	}
 	return removed
 }
@@ -221,10 +287,11 @@ func (s *VectorStore) Prune() int {
 func (s *VectorStore) StartCompaction(ctx context.Context, interval time.Duration) <-chan struct{} {
 	done := make(chan struct{})
 	if interval <= 0 {
-		interval = time.Minute
+		interval = DefaultVectorStoreCompactionEvery
 	}
 	go func() {
 		defer close(done)
+		s.Prune()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -241,11 +308,17 @@ func (s *VectorStore) StartCompaction(ctx context.Context, interval time.Duratio
 
 // Search returns top-k items sorted by cosine similarity to the query embedding.
 func (s *VectorStore) Search(query []float32, k int) []SearchResult {
-	if k <= 0 || len(s.items) == 0 {
+	if k <= 0 {
 		return nil
 	}
 
 	s.Prune()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.items) == 0 {
+		return nil
+	}
+
 	results := make([]SearchResult, 0, len(s.items))
 	now := time.Now()
 	for _, item := range s.items {
@@ -300,8 +373,7 @@ func (s *VectorStore) duplicateEmbedding(item MemoryItem) *MemoryItem {
 	return nil
 }
 
-func (s *VectorStore) enforceLimits() {
-	s.Prune()
+func (s *VectorStore) enforceLimitsLocked() {
 	opts := s.options()
 	if opts.MaxItemsPerScope > 0 {
 		s.evictByScope(opts.MaxItemsPerScope)
@@ -335,7 +407,7 @@ func (s *VectorStore) evictByScope(maxItems int) {
 }
 
 func (s *VectorStore) evictBySize(maxBytes int64) {
-	for int64(s.encodedSize()) > maxBytes && len(s.items) > 0 {
+	for int64(s.encodedSizeLocked()) > maxBytes && len(s.items) > 0 {
 		oldest := 0
 		for i := 1; i < len(s.items); i++ {
 			if s.items[i].TS.Before(s.items[oldest].TS) {
@@ -346,8 +418,8 @@ func (s *VectorStore) evictBySize(maxBytes int64) {
 	}
 }
 
-func (s *VectorStore) encodedSize() int {
-	data, err := json.Marshal(s.items)
+func (s *VectorStore) encodedSizeLocked() int {
+	data, err := json.MarshalIndent(s.items, "", "  ")
 	if err != nil {
 		return 0
 	}
@@ -367,6 +439,13 @@ func (s *VectorStore) removeIndexes(remove map[int]struct{}) {
 
 func (s *VectorStore) options() VectorStoreOptions {
 	return normalizeOptions(s.opts)
+}
+
+func (s *VectorStore) lockFile() func() {
+	lockAny, _ := vectorStoreFileLocks.LoadOrStore(filepath.Clean(s.runPath), &sync.Mutex{})
+	lock := lockAny.(*sync.Mutex)
+	lock.Lock()
+	return lock.Unlock
 }
 
 func normalizeOptions(opts VectorStoreOptions) VectorStoreOptions {

--- a/internal/memory/vector_test.go
+++ b/internal/memory/vector_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -241,8 +243,12 @@ func TestVectorStore_EvictsByScopeAndStoreSize(t *testing.T) {
 			t.Fatalf("size Add(%d) error = %v", i, err)
 		}
 	}
-	if int64(s.encodedSize()) > s.options().MaxStoreBytes {
-		t.Fatalf("encoded size = %d, max = %d", s.encodedSize(), s.options().MaxStoreBytes)
+	info, err := os.Stat(s.runPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > s.options().MaxStoreBytes {
+		t.Fatalf("persisted size = %d, max = %d", info.Size(), s.options().MaxStoreBytes)
 	}
 	if len(s.items) == 0 || s.items[len(s.items)-1].ID != "h" {
 		t.Fatalf("size eviction should keep newest item, got %+v", s.items)
@@ -264,6 +270,50 @@ func TestVectorStore_StartCompactionPrunesInBackground(t *testing.T) {
 	<-done
 	if len(s.items) != 1 || s.items[0].ID != "live" {
 		t.Fatalf("compaction did not prune expired item: %+v", s.items)
+	}
+}
+
+func TestVectorStore_ConcurrentCompactionOperations(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := NewWorkspaceVectorStore(tmpDir).WithOptions(VectorStoreOptions{
+		DefaultTTL:       -1,
+		MaxItemsPerScope: -1,
+		MaxStoreBytes:    -1,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := s.StartCompaction(ctx, time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 40; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.Add(MemoryItem{
+				ID:      fmt.Sprintf("item-%02d", i),
+				Content: fmt.Sprintf("memory %02d", i),
+				TS:      time.Now().UTC().Add(time.Duration(i) * time.Millisecond),
+			}); err != nil {
+				t.Errorf("Add(%d) error = %v", i, err)
+			}
+			_ = s.Items()
+			_ = s.Search([]float32{1, 2, 3}, 3)
+		}()
+	}
+	wg.Wait()
+	cancel()
+	<-done
+
+	reloaded := NewWorkspaceVectorStore(tmpDir).WithOptions(VectorStoreOptions{
+		DefaultTTL:       -1,
+		MaxItemsPerScope: -1,
+		MaxStoreBytes:    -1,
+	})
+	if err := reloaded.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.Items()) != 40 {
+		t.Fatalf("persisted items = %d, want 40", len(reloaded.Items()))
 	}
 }
 

--- a/internal/memory/vector_test.go
+++ b/internal/memory/vector_test.go
@@ -1,8 +1,11 @@
 package memory
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -155,9 +158,6 @@ func TestVectorStore_Prune(t *testing.T) {
 			{ID: "future", Content: "not yet", Category: "note", ExpiresAt: &future},
 		},
 	}
-	if err := s.Save(); err != nil {
-		t.Fatal(err)
-	}
 	removed := s.Prune()
 	if removed != 1 {
 		t.Fatalf("expected 1 removed, got %d", removed)
@@ -170,6 +170,123 @@ func TestVectorStore_Prune(t *testing.T) {
 	}
 }
 
+func TestVectorStore_DefaultTTLAndDuplicateEmbedding(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := NewWorkspaceVectorStore(tmpDir)
+
+	item := MemoryItem{
+		ID:        "ttl",
+		Content:   "expires by default",
+		Embedding: []float32{1, 0, 0},
+		TS:        time.Now().UTC(),
+	}
+	if err := s.Add(item); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if len(s.items) != 1 || s.items[0].ExpiresAt == nil {
+		t.Fatalf("default TTL not applied: %+v", s.items)
+	}
+	if got, want := s.items[0].ExpiresAt.Sub(item.TS), DefaultVectorStoreTTL; got != want {
+		t.Fatalf("ttl = %s, want %s", got, want)
+	}
+
+	err := s.Add(MemoryItem{
+		ID:        "dupe",
+		Content:   "same embedding",
+		Embedding: []float32{1, 0, 0},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate embedding error")
+	}
+}
+
+func TestVectorStore_EvictsByScopeAndStoreSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := NewWorkspaceVectorStore(tmpDir).WithOptions(VectorStoreOptions{
+		DefaultTTL:       -1,
+		MaxItemsPerScope: 2,
+		MaxStoreBytes:    -1,
+	})
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		if err := s.Add(MemoryItem{
+			ID:      fmt.Sprintf("%c", 'a'+i),
+			Content: "scoped memory",
+			Metadata: Metadata{Tags: map[string]string{
+				"scope": "workspace",
+			}},
+			TS: base.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("Add(%d) error = %v", i, err)
+		}
+	}
+	if got := len(s.items); got != 2 {
+		t.Fatalf("items after scope eviction = %d, want 2", got)
+	}
+	if s.items[0].ID != "c" || s.items[1].ID != "d" {
+		t.Fatalf("scope eviction kept %+v, want c/d", s.items)
+	}
+
+	s = NewWorkspaceVectorStore(filepath.Join(tmpDir, "size")).WithOptions(VectorStoreOptions{
+		DefaultTTL:       -1,
+		MaxItemsPerScope: -1,
+		MaxStoreBytes:    380,
+	})
+	for i := 0; i < 8; i++ {
+		if err := s.Add(MemoryItem{
+			ID:      fmt.Sprintf("%c", 'a'+i),
+			Content: "large memory payload " + fmt.Sprintf("%c", 'a'+i) + " " + strings.Repeat("x", 80),
+			TS:      base.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("size Add(%d) error = %v", i, err)
+		}
+	}
+	if int64(s.encodedSize()) > s.options().MaxStoreBytes {
+		t.Fatalf("encoded size = %d, max = %d", s.encodedSize(), s.options().MaxStoreBytes)
+	}
+	if len(s.items) == 0 || s.items[len(s.items)-1].ID != "h" {
+		t.Fatalf("size eviction should keep newest item, got %+v", s.items)
+	}
+}
+
+func TestVectorStore_StartCompactionPrunesInBackground(t *testing.T) {
+	tmpDir := t.TempDir()
+	past := time.Now().Add(-time.Hour)
+	s := NewWorkspaceVectorStore(tmpDir)
+	s.items = []MemoryItem{
+		{ID: "expired", Content: "old", ExpiresAt: &past},
+		{ID: "live", Content: "new"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := s.StartCompaction(ctx, time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+	if len(s.items) != 1 || s.items[0].ID != "live" {
+		t.Fatalf("compaction did not prune expired item: %+v", s.items)
+	}
+}
+
+func TestVectorStore_SearchScaleThousandItems(t *testing.T) {
+	s := NewWorkspaceVectorStore(t.TempDir())
+	for i := 0; i < 1500; i++ {
+		s.items = append(s.items, MemoryItem{
+			ID:        fmt.Sprintf("item-%04d", i),
+			Content:   "scale memory",
+			Embedding: []float32{float32(i % 17), float32((i * 7) % 31), 1},
+			TS:        time.Now().Add(time.Duration(i) * time.Millisecond),
+		})
+	}
+	start := time.Now()
+	results := s.Search([]float32{1, 1, 1}, 5)
+	if len(results) != 5 {
+		t.Fatalf("results = %d, want 5", len(results))
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("search over 1500 items took %s", elapsed)
+	}
+}
+
 func TestVectorStore_CategoryPersistence(t *testing.T) {
 	tmpDir := t.TempDir()
 	s := &VectorStore{
@@ -178,9 +295,9 @@ func TestVectorStore_CategoryPersistence(t *testing.T) {
 	}
 	exp := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
 	item := MemoryItem{
-		ID:       "cat-1",
-		Content:  "prefer postgres",
-		Category: "preference",
+		ID:        "cat-1",
+		Content:   "prefer postgres",
+		Category:  "preference",
 		ExpiresAt: &exp,
 	}
 	if err := s.Add(item); err != nil {


### PR DESCRIPTION
## Summary
- add bounded vector store lifecycle defaults: 7-day TTL, per-scope item caps, total JSON store-size cap, and background compaction
- reject duplicate embeddings before insert so vector collisions are explicit instead of silently duplicated
- prune expired vector memories on load/search/list paths and keep search bounded under 1000+ items
- document the vector store lifecycle in AGENTS.md

Fixes #224

## Verification
- ./scripts/lint.sh
- env GOCACHE=/tmp/v100-issue224-gocache go test -coverprofile=/tmp/v100-issue224-memory.cover ./internal/memory (89.5% coverage)
- env GOCACHE=/tmp/v100-issue224-gocache go test -race ./internal/memory ./internal/tools -run 'TestVectorStore|TestBlackboard|TestLoadAudit|TestForgetAudit'
- env GOCACHE=/tmp/v100-issue224-gocache go test ./...
- env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue224 GIT_WORK_TREE=/tmp/v100-issue224 GOCACHE=/tmp/v100-issue224-gocache go build ./...

Note: full tests were run outside the sandbox because existing tests use local httptest sockets and HOME writes.
