### PR TITLE
feat: validate config in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Bootstrap your configuration and check your environment:
 ./v100 doctor
 ```
 
+`v100 doctor` validates `config.toml` plus behavior directories next to it
+(`agents/`, `policies/`, and `tasks/`). It reports malformed TOML, unknown or
+deprecated keys, missing prompt files, missing referenced providers/tasks, and
+provider fallback cycles before doing provider auth, tool binary, sandbox, and
+`runs/` write checks. Use `./v100 doctor --dry-run` to run only the config and
+behavior-dir validation without network probes or filesystem write checks.
+
 ### 2. Interactive & Unattended Runs
 
 Start a standard interactive run using MiniMax (the preferred provider):

--- a/cmd/v100/cmd_admin.go
+++ b/cmd/v100/cmd_admin.go
@@ -330,9 +330,10 @@ func logoutCmd() *cobra.Command {
 }
 
 func doctorCmd(cfgPath *string) *cobra.Command {
-	return &cobra.Command{
+	var dryRun bool
+	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Check provider auth, tool availability, and run dir",
+		Short: "Check config, provider auth, tool availability, and run dir",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			fmt.Println(ui.Header("v100 doctor"))
 			fmt.Println()
@@ -348,6 +349,21 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 			} else {
 				fmt.Println(ui.Fail("Config not found at " + cfgFile + " — run: v100 config init"))
 				ok = false
+			}
+			validation := config.ValidateConfigPath(cfgFile)
+			printConfigValidation(validation)
+			if validation.HasErrors() {
+				ok = false
+			}
+			if dryRun {
+				fmt.Println(ui.Info("Dry run: skipped provider authentication, network probes, tool binary probes, and runs/ write check."))
+				fmt.Println()
+				if ok {
+					fmt.Println(ui.OK(ui.Bold("All validation checks passed")))
+				} else {
+					fmt.Println(ui.Fail(ui.Bold("Validation checks failed — fix issues above before running")))
+				}
+				return nil
 			}
 
 			cfg, err := loadConfig(*cfgPath)
@@ -618,6 +634,38 @@ func doctorCmd(cfgPath *string) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate config and behavior dirs without provider/network/write checks")
+	return cmd
+}
+
+func printConfigValidation(result *config.ValidationResult) {
+	if result == nil {
+		return
+	}
+	for _, finding := range result.Findings {
+		msg := finding.Message
+		if strings.TrimSpace(finding.Path) != "" {
+			msg = finding.Path + ": " + msg
+		}
+		switch finding.Severity {
+		case config.ValidationError:
+			fmt.Println(ui.Fail(msg))
+		case config.ValidationWarning:
+			fmt.Println(ui.Warn(msg))
+		case config.ValidationInfo:
+			fmt.Println(ui.Dim(msg))
+		}
+	}
+	errors, warnings, _ := result.Counts()
+	if errors > 0 {
+		fmt.Println(ui.Fail(fmt.Sprintf("Config validation: %d error(s), %d warning(s)", errors, warnings)))
+		return
+	}
+	if warnings > 0 {
+		fmt.Println(ui.Warn(fmt.Sprintf("Config validation: 0 error(s), %d warning(s)", warnings)))
+		return
+	}
+	fmt.Println(ui.OK("Config validation: ok"))
 }
 
 func executorResourceStatusLine() (string, bool, bool) {

--- a/cmd/v100/cmd_admin_test.go
+++ b/cmd/v100/cmd_admin_test.go
@@ -144,3 +144,35 @@ func TestConfigInitDoesNotWritePlaintextOAuthTemplate(t *testing.T) {
 		t.Fatalf("config init output missing secure guidance:\n%s", out)
 	}
 }
+
+func TestDoctorDryRunValidatesWithoutWritingRunsDir(t *testing.T) {
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[defaults]
+provider = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := withWorkingDir(root, func() error {
+		out, err := captureStdout(func() error {
+			cmd := doctorCmd(&cfgPath)
+			cmd.SetArgs([]string{"--dry-run"})
+			return cmd.Execute()
+		})
+		if err != nil {
+			return err
+		}
+		for _, want := range []string{"Config validation: ok", "Dry run: skipped provider authentication"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("doctor --dry-run output missing %q in:\n%s", want, out)
+			}
+		}
+		if _, err := os.Stat(filepath.Join(root, "runs")); !os.IsNotExist(err) {
+			t.Fatalf("doctor --dry-run created runs dir or stat failed: %v", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -458,7 +458,10 @@ check_interval = "24h"
 func Load(path string) (*Config, error) {
 	// Try loading .env first if it exists in the current directory or parent
 	_ = LoadDotEnv(".env")
+	return loadConfigFile(path)
+}
 
+func loadConfigFile(path string) (*Config, error) {
 	path = expandHome(path)
 	sourceDir := configSourceDir(path)
 	data, err := os.ReadFile(path)

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -1,0 +1,388 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type ValidationSeverity string
+
+const (
+	ValidationError   ValidationSeverity = "error"
+	ValidationWarning ValidationSeverity = "warning"
+	ValidationInfo    ValidationSeverity = "info"
+)
+
+type ValidationFinding struct {
+	Severity ValidationSeverity
+	Path     string
+	Message  string
+}
+
+type ValidationResult struct {
+	ConfigPath string
+	Findings   []ValidationFinding
+}
+
+func (r *ValidationResult) Add(severity ValidationSeverity, path, message string) {
+	r.Findings = append(r.Findings, ValidationFinding{
+		Severity: severity,
+		Path:     path,
+		Message:  message,
+	})
+}
+
+func (r *ValidationResult) HasErrors() bool {
+	for _, f := range r.Findings {
+		if f.Severity == ValidationError {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ValidationResult) Counts() (errors, warnings, info int) {
+	for _, f := range r.Findings {
+		switch f.Severity {
+		case ValidationError:
+			errors++
+		case ValidationWarning:
+			warnings++
+		case ValidationInfo:
+			info++
+		}
+	}
+	return errors, warnings, info
+}
+
+var deprecatedConfigKeys = map[string]string{
+	"defaults.max_tool_calls": "defaults.max_tool_calls_per_step",
+	"tools.allow":             "tools.enabled",
+	"tools.deny":              "tools.dangerous",
+}
+
+// ValidateConfigPath validates config.toml and the behavior directories beside it.
+func ValidateConfigPath(path string) *ValidationResult {
+	path = expandHome(path)
+	result := &ValidationResult{ConfigPath: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		result.Add(ValidationError, path, fmt.Sprintf("read config: %v", err))
+		return result
+	}
+
+	var raw Config
+	md, err := toml.Decode(string(data), &raw)
+	if err != nil {
+		result.Add(ValidationError, path, fmt.Sprintf("TOML syntax error in config: %v", err))
+		return result
+	}
+	warnUndecodedKeys(result, path, md.Undecoded())
+	raw.SourceDir = configSourceDir(path)
+
+	validateBehaviorDirectories(result, raw.PromptBaseDir())
+	if result.HasErrors() {
+		return result
+	}
+
+	cfg, err := loadConfigFile(path)
+	if err != nil {
+		result.Add(ValidationError, path, fmt.Sprintf("load effective config: %v", err))
+		return result
+	}
+	validateEffectiveConfig(result, cfg)
+	return result
+}
+
+func warnUndecodedKeys(result *ValidationResult, path string, keys []toml.Key) {
+	for _, key := range keys {
+		name := key.String()
+		if replacement, ok := deprecatedConfigKeys[name]; ok {
+			result.Add(ValidationWarning, path, fmt.Sprintf("deprecated config key %q; use %q", name, replacement))
+			continue
+		}
+		result.Add(ValidationWarning, path, fmt.Sprintf("unused config key or section %q", name))
+	}
+}
+
+func validateBehaviorDirectories(result *ValidationResult, baseDir string) {
+	validateAgentsDir(result, filepath.Join(baseDir, "agents"))
+	validatePoliciesDir(result, filepath.Join(baseDir, "policies"))
+	validateTasksDir(result, filepath.Join(baseDir, "tasks"))
+}
+
+func validateAgentsDir(result *ValidationResult, dir string) {
+	entries, err := sortedDirEntries(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.Add(ValidationInfo, dir, "behavior dir agents/ not present")
+			return
+		}
+		result.Add(ValidationError, dir, fmt.Sprintf("read agents directory: %v", err))
+		return
+	}
+	seen := map[string]string{}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".toml") {
+			continue
+		}
+		count++
+		path := filepath.Join(dir, entry.Name())
+		name := strings.TrimSuffix(entry.Name(), ".toml")
+		if prev, ok := seen[name]; ok {
+			result.Add(ValidationError, path, fmt.Sprintf("duplicate agent definition %q also defined in %s", name, prev))
+			continue
+		}
+		seen[name] = path
+		var agent AgentConfig
+		md, err := decodeTOMLFile(path, &agent)
+		if err != nil {
+			result.Add(ValidationError, path, fmt.Sprintf("TOML syntax error in agent definition: %v", err))
+			continue
+		}
+		warnUndecodedKeys(result, path, md.Undecoded())
+		validatePromptPath(result, path, agent.SystemPromptPath, configSourceDir(path), "system_prompt_path")
+	}
+	result.Add(ValidationInfo, dir, fmt.Sprintf("behavior dir agents/: %d agent definition(s)", count))
+}
+
+func validatePoliciesDir(result *ValidationResult, dir string) {
+	entries, err := sortedDirEntries(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.Add(ValidationInfo, dir, "behavior dir policies/ not present")
+			return
+		}
+		result.Add(ValidationError, dir, fmt.Sprintf("read policies directory: %v", err))
+		return
+	}
+	seen := map[string]string{}
+	count := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		switch {
+		case entry.IsDir():
+			manifestPath := filepath.Join(path, policyManifestName)
+			if _, err := os.Stat(manifestPath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				result.Add(ValidationError, manifestPath, fmt.Sprintf("stat policy manifest: %v", err))
+				continue
+			}
+			count += validatePolicyTOML(result, manifestPath, name, seen)
+		case strings.HasSuffix(name, ".toml") && name != policyManifestName:
+			key := strings.TrimSuffix(name, ".toml")
+			count += validatePolicyTOML(result, path, key, seen)
+		}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") && !strings.HasSuffix(name, ".txt") {
+			continue
+		}
+		key := strings.TrimSuffix(name, filepath.Ext(name))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = filepath.Join(dir, name)
+		count++
+	}
+	result.Add(ValidationInfo, dir, fmt.Sprintf("behavior dir policies/: %d policy definition(s)", count))
+}
+
+func validatePolicyTOML(result *ValidationResult, path, name string, seen map[string]string) int {
+	if prev, ok := seen[name]; ok {
+		result.Add(ValidationError, path, fmt.Sprintf("duplicate policy definition %q also defined in %s", name, prev))
+		return 0
+	}
+	seen[name] = path
+	var policy PolicyConfig
+	md, err := decodeTOMLFile(path, &policy)
+	if err != nil {
+		result.Add(ValidationError, path, fmt.Sprintf("TOML syntax error in policy definition: %v", err))
+		return 1
+	}
+	warnUndecodedKeys(result, path, md.Undecoded())
+	validatePromptPath(result, path, policy.SystemPromptPath, configSourceDir(path), "system_prompt_path")
+	return 1
+}
+
+func validateTasksDir(result *ValidationResult, dir string) {
+	entries, err := sortedDirEntries(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.Add(ValidationInfo, dir, "behavior dir tasks/ not present")
+			return
+		}
+		result.Add(ValidationError, dir, fmt.Sprintf("read tasks directory: %v", err))
+		return
+	}
+	seen := map[string]string{}
+	count := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		switch {
+		case entry.IsDir():
+			manifestPath := filepath.Join(path, taskManifestName)
+			if _, err := os.Stat(manifestPath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				result.Add(ValidationError, manifestPath, fmt.Sprintf("stat task manifest: %v", err))
+				continue
+			}
+			count += validateTaskTOML(result, manifestPath, name, seen)
+		case strings.HasSuffix(name, ".toml") && name != taskManifestName:
+			defaultName := strings.TrimSuffix(name, ".toml")
+			count += validateTaskTOML(result, path, defaultName, seen)
+		}
+	}
+	result.Add(ValidationInfo, dir, fmt.Sprintf("behavior dir tasks/: %d task definition(s)", count))
+}
+
+func validateTaskTOML(result *ValidationResult, path, defaultName string, seen map[string]string) int {
+	var task WakeTask
+	md, err := decodeTOMLFile(path, &task)
+	if err != nil {
+		result.Add(ValidationError, path, fmt.Sprintf("TOML syntax error in task definition: %v", err))
+		return 1
+	}
+	warnUndecodedKeys(result, path, md.Undecoded())
+	name := strings.TrimSpace(task.Name)
+	if name == "" {
+		name = defaultName
+	}
+	if prev, ok := seen[name]; ok {
+		result.Add(ValidationError, path, fmt.Sprintf("duplicate task definition %q also defined in %s", name, prev))
+		return 1
+	}
+	seen[name] = path
+	baseDir := configSourceDir(path)
+	for i, step := range task.Steps {
+		validatePromptPath(result, path, step.PromptPath, baseDir, fmt.Sprintf("steps[%d].prompt_path", i))
+	}
+	return 1
+}
+
+func validatePromptPath(result *ValidationResult, ownerPath, rawPath, baseDir, field string) {
+	if strings.TrimSpace(rawPath) == "" {
+		return
+	}
+	resolved := ResolvePromptFilePath(rawPath, baseDir)
+	if _, err := os.Stat(resolved); err != nil {
+		result.Add(ValidationError, ownerPath, fmt.Sprintf("%s references missing file %q: %v", field, resolved, err))
+	}
+}
+
+func validateEffectiveConfig(result *ValidationResult, cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	checkProviderReference(result, cfg, "defaults.provider", cfg.Defaults.Provider, true)
+	checkProviderReference(result, cfg, "defaults.smart_provider", cfg.Defaults.SmartProvider, false)
+	checkProviderReference(result, cfg, "defaults.sub_provider", cfg.Defaults.SubProvider, false)
+	checkProviderReference(result, cfg, "defaults.cheap_provider", cfg.Defaults.CheapProvider, false)
+	checkProviderReference(result, cfg, "defaults.compress_provider", cfg.Defaults.CompressProvider, false)
+	checkProviderReference(result, cfg, "wake.provider", cfg.Wake.Provider, false)
+	checkProviderReference(result, cfg, "embedding.provider", cfg.Embedding.Provider, false)
+
+	for providerName, provider := range cfg.Providers {
+		for _, fallback := range provider.Fallbacks {
+			checkProviderReference(result, cfg, "providers."+providerName+".fallbacks", fallback, true)
+		}
+	}
+	validateProviderFallbackCycles(result, cfg)
+	validateWakeTaskReference(result, cfg)
+}
+
+func checkProviderReference(result *ValidationResult, cfg *Config, field, name string, required bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		if required {
+			result.Add(ValidationError, field, "provider reference is empty")
+		}
+		return
+	}
+	if _, ok := cfg.Providers[name]; !ok {
+		result.Add(ValidationError, field, fmt.Sprintf("references provider %q, but no [providers.%s] config exists", name, name))
+	}
+}
+
+func validateWakeTaskReference(result *ValidationResult, cfg *Config) {
+	name := strings.TrimSpace(cfg.Wake.Task)
+	if name == "" {
+		return
+	}
+	for _, task := range cfg.Wake.Tasks {
+		if task.Name == name {
+			return
+		}
+	}
+	result.Add(ValidationError, "wake.task", fmt.Sprintf("references task %q, but no matching [[wake.tasks]] or tasks/ definition exists", name))
+}
+
+func validateProviderFallbackCycles(result *ValidationResult, cfg *Config) {
+	graph := map[string][]string{}
+	for name, provider := range cfg.Providers {
+		for _, fallback := range provider.Fallbacks {
+			if _, ok := cfg.Providers[fallback]; ok {
+				graph[name] = append(graph[name], fallback)
+			}
+		}
+		sort.Strings(graph[name])
+	}
+	visiting := map[string]bool{}
+	visited := map[string]bool{}
+	var stack []string
+	var visit func(string) bool
+	visit = func(name string) bool {
+		if visiting[name] {
+			cycle := append(stack, name)
+			result.Add(ValidationError, "providers."+name+".fallbacks", "provider fallback cycle: "+strings.Join(cycle, " -> "))
+			return true
+		}
+		if visited[name] {
+			return false
+		}
+		visiting[name] = true
+		stack = append(stack, name)
+		for _, fallback := range graph[name] {
+			if visit(fallback) {
+				return true
+			}
+		}
+		stack = stack[:len(stack)-1]
+		visiting[name] = false
+		visited[name] = true
+		return false
+	}
+	for _, name := range sortedMapKeys(graph) {
+		if visit(name) {
+			return
+		}
+	}
+}
+
+func decodeTOMLFile(path string, dst any) (toml.MetaData, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return toml.MetaData{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	md, err := toml.Decode(string(data), dst)
+	if err != nil {
+		return toml.MetaData{}, err
+	}
+	return md, nil
+}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateConfigPathBehaviorDirsAndReferences(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.toml"), `[defaults]
+provider = "codex"
+
+[wake]
+task = "nightly"
+`)
+	writeFile(t, filepath.Join(dir, "agents", "coder.md"), "coder prompt")
+	writeFile(t, filepath.Join(dir, "agents", "coder.toml"), `system_prompt_path = "coder.md"`)
+	writeFile(t, filepath.Join(dir, "policies", "review.md"), "review prompt")
+	writeFile(t, filepath.Join(dir, "tasks", "nightly", "step.md"), "step prompt")
+	writeFile(t, filepath.Join(dir, "tasks", "nightly", "task.toml"), `[[steps]]
+name = "read"
+prompt_path = "step.md"
+`)
+
+	result := ValidateConfigPath(filepath.Join(dir, "config.toml"))
+	if result.HasErrors() {
+		t.Fatalf("ValidateConfigPath() errors: %+v", result.Findings)
+	}
+	for _, want := range []string{
+		"behavior dir agents/: 1 agent definition(s)",
+		"behavior dir policies/: 1 policy definition(s)",
+		"behavior dir tasks/: 1 task definition(s)",
+	} {
+		if !hasFinding(result, ValidationInfo, want) {
+			t.Fatalf("missing info %q in %+v", want, result.Findings)
+		}
+	}
+}
+
+func TestValidateConfigPathMalformedRootTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[defaults`)
+
+	result := ValidateConfigPath(path)
+	if !hasFinding(result, ValidationError, "TOML syntax error in config") {
+		t.Fatalf("missing malformed TOML error: %+v", result.Findings)
+	}
+}
+
+func TestValidateConfigPathMissingBehaviorDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[defaults]
+provider = "codex"
+`)
+
+	result := ValidateConfigPath(path)
+	if result.HasErrors() {
+		t.Fatalf("missing behavior dirs should not be errors: %+v", result.Findings)
+	}
+	for _, want := range []string{
+		"behavior dir agents/ not present",
+		"behavior dir policies/ not present",
+		"behavior dir tasks/ not present",
+	} {
+		if !hasFinding(result, ValidationInfo, want) {
+			t.Fatalf("missing info %q in %+v", want, result.Findings)
+		}
+	}
+}
+
+func TestValidateConfigPathWarnsUnusedAndDeprecatedKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[defaults]
+provider = "codex"
+max_tool_calls = 3
+
+[unused]
+value = true
+`)
+
+	result := ValidateConfigPath(path)
+	if !hasFinding(result, ValidationWarning, `deprecated config key "defaults.max_tool_calls"`) {
+		t.Fatalf("missing deprecated warning: %+v", result.Findings)
+	}
+	if !hasFinding(result, ValidationWarning, `unused config key or section "unused.value"`) {
+		t.Fatalf("missing unused warning: %+v", result.Findings)
+	}
+}
+
+func TestValidateConfigPathBehaviorDirSyntaxAndMissingPrompt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[defaults]
+provider = "codex"
+`)
+	writeFile(t, filepath.Join(dir, "agents", "bad.toml"), `system_prompt = `)
+	writeFile(t, filepath.Join(dir, "policies", "missing.toml"), `system_prompt_path = "missing.md"`)
+
+	result := ValidateConfigPath(path)
+	if !hasFinding(result, ValidationError, "TOML syntax error in agent definition") {
+		t.Fatalf("missing behavior TOML error: %+v", result.Findings)
+	}
+	if !hasFinding(result, ValidationError, "system_prompt_path references missing file") {
+		t.Fatalf("missing prompt-path error: %+v", result.Findings)
+	}
+}
+
+func TestValidateConfigPathProviderReferencesAndCycles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[providers.a]
+type = "openai"
+fallbacks = ["b"]
+
+[providers.b]
+type = "openai"
+fallbacks = ["a"]
+
+[defaults]
+provider = "missing"
+`)
+
+	result := ValidateConfigPath(path)
+	if !hasFinding(result, ValidationError, `references provider "missing"`) {
+		t.Fatalf("missing provider reference error: %+v", result.Findings)
+	}
+	if !hasFinding(result, ValidationError, "provider fallback cycle") {
+		t.Fatalf("missing provider cycle error: %+v", result.Findings)
+	}
+}
+
+func TestValidateConfigPathWakeTaskReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	writeFile(t, path, `[defaults]
+provider = "codex"
+
+[wake]
+task = "missing-task"
+`)
+
+	result := ValidateConfigPath(path)
+	if !hasFinding(result, ValidationError, `references task "missing-task"`) {
+		t.Fatalf("missing wake task reference error: %+v", result.Findings)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasFinding(result *ValidationResult, severity ValidationSeverity, needle string) bool {
+	for _, finding := range result.Findings {
+		if finding.Severity == severity && strings.Contains(finding.Message, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add config validation for config.toml and behavior dirs: agents/, policies/, tasks/
- report malformed TOML, unused/deprecated keys, missing prompt files, missing provider/task references, and provider fallback cycles
- add doctor --dry-run for validation-only checks without provider/network/write probes
- document the doctor validation surface in README

Fixes #221

## Verification
- ./scripts/lint.sh
- env GOCACHE=/tmp/v100-issue221-gocache go test -coverprofile=/tmp/v100-issue221-config.cover ./internal/config  # 80.7% coverage
- env GOCACHE=/tmp/v100-issue221-gocache go test ./...  # rerun outside sandbox after HOME/socket sandbox failures
- env GIT_DIR=/home/v/main/ai/v100/.git/worktrees/v100-issue221 GIT_WORK_TREE=/tmp/v100-issue221 GOCACHE=/tmp/v100-issue221-gocache go build ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag to `v100 doctor` for validating configuration without network probes or write checks.
  * Enhanced `v100 doctor` to validate configuration files, prompt file references, and detect provider fallback cycles.

* **Documentation**
  * Updated documentation describing all validation checks performed by `v100 doctor`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tripledoublev/v100/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->