### PR TITLE
fix: render TUI review responses immediately

### DIFF
--- a/internal/ui/events.go
+++ b/internal/ui/events.go
@@ -51,6 +51,20 @@ func (m *TUIModel) appendEvent(ev core.Event) {
 		var p core.UserMsgPayload
 		_ = json.Unmarshal(ev.Payload, &p)
 		if !sub {
+			if p.Source == "reviewer" {
+				if role, text, ok := parseExternalReviewContent(p.Content); ok {
+					if !m.consumePendingReviewTrace(role, text) {
+						m.addItem(&TranscriptItem{
+							Type:      ItemMessage,
+							Role:      role,
+							Text:      text,
+							Timestamp: ev.TS,
+						})
+						_, _ = fmt.Fprintf(&m.plainBuf, "\n%s: %s\n", role, text)
+					}
+					break
+				}
+			}
 			role := "user"
 			if p.Source == "system" {
 				role = "system"
@@ -282,6 +296,26 @@ func (m *TUIModel) addItem(item *TranscriptItem) {
 	item.ID = m.nextItemID
 	m.nextItemID++
 	m.history = append(m.history, item)
+}
+
+func (m *TUIModel) markReviewTracePending(itemID int) {
+	for _, item := range m.history {
+		if item.ID == itemID {
+			item.pendingReviewTrace = true
+			return
+		}
+	}
+}
+
+func (m *TUIModel) consumePendingReviewTrace(role, text string) bool {
+	text = strings.TrimSpace(text)
+	for _, item := range m.history {
+		if item.pendingReviewTrace && item.Type == ItemMessage && item.Role == role && strings.TrimSpace(item.Text) == text {
+			item.pendingReviewTrace = false
+			return true
+		}
+	}
+	return false
 }
 
 func (m *TUIModel) getOrCreateToolGroup() *TranscriptItem {
@@ -614,6 +648,11 @@ func (m *TUIModel) updateStatus(ev core.Event) {
 		}
 		m.runSummary = fmt.Sprintf("v100 run %s  %s · %s", runShort, p.Provider, p.Model)
 	case core.EventUserMsg:
+		var p core.UserMsgPayload
+		_ = json.Unmarshal(ev.Payload, &p)
+		if p.Source == "reviewer" {
+			return
+		}
 		m.StatusMode = i18n.StatusThinking
 		m.statusMode = m.StatusMode.String()
 		m.statusLine = pickStatusLine(m.statusTick, []string{

--- a/internal/ui/message_actions.go
+++ b/internal/ui/message_actions.go
@@ -69,6 +69,33 @@ func buildReviewPrompt(contextUser, assistantText string) string {
 	return "Please review the following assistant response.\n\nOriginal user request:\n" + contextUser + "\n\nAssistant response:\n" + assistantText
 }
 
+const externalReviewGuidance = "This is feedback on the previous assistant response. Incorporate it when relevant."
+
+func externalReviewConversationContent(label, output string) string {
+	return "[external review: " + label + "]\n" +
+		externalReviewGuidance + "\n\n" +
+		output
+}
+
+func parseExternalReviewContent(content string) (string, string, bool) {
+	content = strings.TrimSpace(content)
+	const prefix = "[external review: "
+	if !strings.HasPrefix(content, prefix) {
+		return "", "", false
+	}
+	end := strings.Index(content, "]")
+	if end <= len(prefix) {
+		return "", "", false
+	}
+	label := strings.TrimSpace(content[len(prefix):end])
+	body := strings.TrimSpace(content[end+1:])
+	body = strings.TrimSpace(strings.TrimPrefix(body, externalReviewGuidance))
+	if label == "" || body == "" {
+		return "", "", false
+	}
+	return label, body, true
+}
+
 func realRunReview(ctx context.Context, kind messageActionKind, prompt string) (string, error) {
 	var cmd *exec.Cmd
 	switch kind {

--- a/internal/ui/message_actions_test.go
+++ b/internal/ui/message_actions_test.go
@@ -270,6 +270,9 @@ func TestReviewDoneRendersTranscriptBeforePersistingReview(t *testing.T) {
 	if view := stripANSI(m.transcript.View()); !strings.Contains(view, "second opinion") {
 		t.Fatalf("visible transcript missing review output: %q", view)
 	}
+	if plain := m.plainBuf.String(); !strings.Contains(plain, "codex: second opinion") {
+		t.Fatalf("plain transcript missing review output: %q", plain)
+	}
 
 	if msg := cmd(); msg != nil {
 		t.Fatalf("persistence command message = %T, want nil", msg)
@@ -282,6 +285,11 @@ func TestReviewDoneRendersTranscriptBeforePersistingReview(t *testing.T) {
 	}
 	if !strings.Contains(gotContent, "[external review: codex]") || !strings.Contains(gotContent, "second opinion") {
 		t.Fatalf("persisted content = %q", gotContent)
+	}
+
+	m.appendEvent(reviewerEvent(t, "codex", "second opinion"))
+	if plain := m.plainBuf.String(); strings.Count(plain, "codex: second opinion") != 1 {
+		t.Fatalf("plain transcript duplicated review output after trace echo: %q", plain)
 	}
 }
 

--- a/internal/ui/message_actions_test.go
+++ b/internal/ui/message_actions_test.go
@@ -2,12 +2,15 @@ package ui
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/tripledoublev/v100/internal/core"
+	"github.com/tripledoublev/v100/internal/i18n"
 )
 
 func TestAssistantActionRowRendersEligibleButtons(t *testing.T) {
@@ -227,6 +230,154 @@ func TestAskActionAppendsReplyAndUsesStubbedRunner(t *testing.T) {
 	}
 	if m.statusLine != "codex replied" {
 		t.Fatalf("statusLine = %q, want codex replied", m.statusLine)
+	}
+}
+
+func TestReviewDoneRendersTranscriptBeforePersistingReview(t *testing.T) {
+	m := NewTUIModel(false, false)
+	m.width = 100
+	m.height = 30
+	m.history = []*TranscriptItem{
+		{ID: 1, Type: ItemMessage, Role: "codex", Text: "", Timestamp: time.Now()},
+	}
+	m.nextItemID = 2
+	m.rebuildTranscript(true)
+
+	var called bool
+	var gotRole, gotContent string
+	m.AppendConversationMessageFn = func(role, content string) {
+		called = true
+		gotRole = role
+		gotContent = content
+	}
+
+	updated, cmd := m.Update(reviewDoneMsg{
+		action: actionAskCodex,
+		itemID: 1,
+		output: "second opinion",
+	})
+	m = updated.(*TUIModel)
+
+	if called {
+		t.Fatal("persistence callback ran synchronously before Update returned")
+	}
+	if cmd == nil {
+		t.Fatal("expected review persistence command")
+	}
+	if out := stripANSI(m.transcriptBuf.String()); !strings.Contains(out, "second opinion") {
+		t.Fatalf("transcript buffer missing review output: %q", out)
+	}
+	if view := stripANSI(m.transcript.View()); !strings.Contains(view, "second opinion") {
+		t.Fatalf("visible transcript missing review output: %q", view)
+	}
+
+	if msg := cmd(); msg != nil {
+		t.Fatalf("persistence command message = %T, want nil", msg)
+	}
+	if !called {
+		t.Fatal("persistence callback did not run from returned command")
+	}
+	if gotRole != "system" {
+		t.Fatalf("persisted role = %q, want system", gotRole)
+	}
+	if !strings.Contains(gotContent, "[external review: codex]") || !strings.Contains(gotContent, "second opinion") {
+		t.Fatalf("persisted content = %q", gotContent)
+	}
+}
+
+func TestReviewerTraceEventRendersAsReviewRoleOnResume(t *testing.T) {
+	m := NewTUIModel(false, false)
+
+	m.appendEvent(reviewerEvent(t, "claude", "second opinion"))
+
+	last := m.history[len(m.history)-1]
+	if last.Role != "claude" || last.Text != "second opinion" {
+		t.Fatalf("last item = %+v, want claude review", last)
+	}
+	out := stripANSI(m.transcriptBuf.String())
+	if !strings.Contains(out, "claude") || !strings.Contains(out, "second opinion") {
+		t.Fatalf("transcript missing reviewer content: %q", out)
+	}
+	if strings.Contains(out, "[external review:") {
+		t.Fatalf("transcript leaked persistence wrapper: %q", out)
+	}
+}
+
+func TestReviewerTraceEventDoesNotDuplicateVisibleReviewItem(t *testing.T) {
+	m := NewTUIModel(false, false)
+	m.history = []*TranscriptItem{
+		{ID: 1, Type: ItemMessage, Role: "codex", Text: "second opinion", Timestamp: time.Now(), pendingReviewTrace: true},
+	}
+	m.nextItemID = 2
+	m.rebuildTranscript(true)
+
+	m.appendEvent(reviewerEvent(t, "codex", "second opinion"))
+
+	var matches int
+	for _, item := range m.history {
+		if item.Type == ItemMessage && item.Role == "codex" && item.Text == "second opinion" {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("codex review message count = %d, want 1", matches)
+	}
+	out := stripANSI(m.transcriptBuf.String())
+	if strings.Count(out, "second opinion") != 1 {
+		t.Fatalf("transcript duplicated review output: %q", out)
+	}
+	if m.history[0].pendingReviewTrace {
+		t.Fatal("expected pending review trace marker to be consumed")
+	}
+}
+
+func TestReviewerTraceEventsKeepDistinctSameTextReviews(t *testing.T) {
+	m := NewTUIModel(false, false)
+
+	m.appendEvent(reviewerEvent(t, "codex", "same note"))
+	m.appendEvent(reviewerEvent(t, "codex", "same note"))
+
+	var matches int
+	for _, item := range m.history {
+		if item.Type == ItemMessage && item.Role == "codex" && item.Text == "same note" {
+			matches++
+		}
+	}
+	if matches != 2 {
+		t.Fatalf("codex same-text review message count = %d, want 2", matches)
+	}
+}
+
+func TestReviewerTraceEventDoesNotOverrideReplyStatus(t *testing.T) {
+	m := NewTUIModel(false, false)
+	m.statusMode = "idle"
+	m.StatusMode = i18n.StatusIdle
+	m.statusLine = "codex replied"
+
+	m.appendEvent(reviewerEvent(t, "codex", "second opinion"))
+
+	if m.statusLine != "codex replied" {
+		t.Fatalf("statusLine = %q, want codex replied", m.statusLine)
+	}
+	if m.statusMode != "idle" {
+		t.Fatalf("statusMode = %q, want idle", m.statusMode)
+	}
+}
+
+func reviewerEvent(t *testing.T, label, output string) core.Event {
+	t.Helper()
+	payload, err := json.Marshal(core.UserMsgPayload{
+		Source:  "reviewer",
+		Content: externalReviewConversationContent(label, output),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return core.Event{
+		RunID:   "run-test",
+		TS:      time.Now(),
+		Type:    core.EventUserMsg,
+		Payload: payload,
 	}
 }
 

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -78,7 +78,6 @@ type ImageRenderedMsg struct {
 	MessageIndex int
 }
 
-
 type ToolExecution struct {
 	CallID    string // for matching call↔result events
 	Name      string
@@ -139,6 +138,8 @@ type TranscriptItem struct {
 	Expanded  bool
 	ID        int
 	Timestamp time.Time
+
+	pendingReviewTrace bool
 }
 
 type toggleTarget struct {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -118,14 +118,17 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusMode = "idle"
 			m.statusLine = reviewLabel(msg.action) + " replied"
-			if strings.TrimSpace(msg.output) != "" && m.AppendConversationMessageFn != nil {
+			if strings.TrimSpace(msg.output) != "" {
 				label := reviewLabel(msg.action)
-				content := externalReviewConversationContent(label, msg.output)
-				appendConversationMessage := m.AppendConversationMessageFn
-				m.markReviewTracePending(msg.itemID)
-				persistReviewCmd = func() tea.Msg {
-					appendConversationMessage("system", content)
-					return nil
+				_, _ = fmt.Fprintf(&m.plainBuf, "\n%s: %s\n", label, msg.output)
+				if m.AppendConversationMessageFn != nil {
+					content := externalReviewConversationContent(label, msg.output)
+					appendConversationMessage := m.AppendConversationMessageFn
+					m.markReviewTracePending(msg.itemID)
+					persistReviewCmd = func() tea.Msg {
+						appendConversationMessage("system", content)
+						return nil
+					}
 				}
 			}
 		}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -92,6 +92,7 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.reviewCancel != nil {
 			m.reviewCancel = nil
 		}
+		var persistReviewCmd tea.Cmd
 		// FIX: use index-based access to modify slice elements in place
 		for idx := range m.history {
 			if m.history[idx].ID == msg.itemID {
@@ -119,13 +120,19 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusLine = reviewLabel(msg.action) + " replied"
 			if strings.TrimSpace(msg.output) != "" && m.AppendConversationMessageFn != nil {
 				label := reviewLabel(msg.action)
-				content := "[external review: " + label + "]\n" +
-					"This is feedback on the previous assistant response. Incorporate it when relevant.\n\n" +
-					msg.output
-				m.AppendConversationMessageFn("system", content)
+				content := externalReviewConversationContent(label, msg.output)
+				appendConversationMessage := m.AppendConversationMessageFn
+				m.markReviewTracePending(msg.itemID)
+				persistReviewCmd = func() tea.Msg {
+					appendConversationMessage("system", content)
+					return nil
+				}
 			}
 		}
 		m.rebuildTranscript(true)
+		if persistReviewCmd != nil {
+			cmds = append(cmds, persistReviewCmd)
+		}
 
 	case tea.KeyMsg:
 		switch msg.String() {


### PR DESCRIPTION
## Summary
- defer external-review persistence out of the Bubble Tea Update path so Ask Codex/Ask Claude responses render immediately
- render reviewer trace events as codex/claude messages on resume without leaking the persistence wrapper
- suppress only the live trace echo for pending review items and keep reviewer trace events status-neutral

Closes #232

## Verification
- GOCACHE=/tmp/v100-go-build go test ./internal/ui
- GOCACHE=/tmp/v100-go-build ./scripts/test.sh
- GOCACHE=/tmp/v100-go-build GOLANGCI_LINT_CACHE=/tmp/v100-golangci ./scripts/lint.sh
- GOCACHE=/tmp/v100-go-build make build
- git diff --check

## Review
- Spawned review subagent; incorporated its same-text replay and status-overwrite findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of external reviews to prevent duplicate entries appearing in conversation transcripts
  * Improved review trace state management to better track and distinguish between pending and completed reviews
  * Refined the persistence workflow for review messages to ensure proper ordering and completeness in transcripts
  * Fixed transcript rendering to properly display reviewer feedback while maintaining existing conversation state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->