### PR TITLE
[codex] add Telegram gateway

### DIFF
--- a/cmd/v100/cmd_acp.go
+++ b/cmd/v100/cmd_acp.go
@@ -23,8 +23,9 @@ import (
 
 func acpCmd(cfgPath *string) *cobra.Command {
 	var (
-		yoloFlag bool
-		autoFlag bool
+		yoloFlag     bool
+		autoFlag     bool
+		providerFlag string
 	)
 
 	cmd := &cobra.Command{
@@ -37,11 +38,12 @@ func acpCmd(cfgPath *string) *cobra.Command {
 
 			conn := acp.NewConn(os.Stdin, realStdout)
 			server := &acpServer{
-				conn:     conn,
-				yolo:     yoloFlag || autoFlag,
-				sessions: make(map[string]*acpSession),
-				cfgPath:  *cfgPath,
-				cmd:      cmd,
+				conn:             conn,
+				yolo:             yoloFlag || autoFlag,
+				sessions:         make(map[string]*acpSession),
+				cfgPath:          *cfgPath,
+				cmd:              cmd,
+				providerOverride: strings.TrimSpace(providerFlag),
 			}
 
 			return server.serve()
@@ -50,6 +52,7 @@ func acpCmd(cfgPath *string) *cobra.Command {
 
 	cmd.Flags().BoolVar(&yoloFlag, "yolo", false, "auto-approve all tool calls")
 	cmd.Flags().BoolVar(&autoFlag, "auto", false, "auto-approve all tool calls")
+	cmd.Flags().StringVar(&providerFlag, "provider", "", "override defaults.provider for this ACP session")
 
 	return cmd
 }
@@ -67,6 +70,16 @@ type acpServer struct {
 	mu               sync.Mutex
 	cfgPath          string
 	cmd              *cobra.Command
+	providerOverride string
+}
+
+// applyProviderOverride forces cfg.Defaults.Provider to the override supplied on
+// the command line (used by gateways that pin a specific provider).
+func (s *acpServer) applyProviderOverride(cfg *config.Config) {
+	if cfg == nil || s.providerOverride == "" {
+		return
+	}
+	cfg.Defaults.Provider = s.providerOverride
 }
 
 type acpSession struct {
@@ -163,6 +176,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 		}
 		cfg, _ := loadConfig(s.cfgPath)
 		if cfg != nil {
+			s.applyProviderOverride(cfg)
 			if prov, err := buildProvider(cfg, cfg.Defaults.Provider); err == nil {
 				res.AgentCapabilities.PromptCapabilities.Image = prov.Capabilities().Images
 			}
@@ -222,6 +236,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 			_ = s.conn.SendError(req.ID, acp.ErrProviderConfiguration, err.Error())
 			return
 		}
+		s.applyProviderOverride(cfg)
 
 		if _, ok := cfg.Providers[cfg.Defaults.Provider]; !ok {
 			defaults := config.DefaultConfig()
@@ -232,6 +247,7 @@ func (s *acpServer) handleRequest(req acp.Request) {
 
 		opts := RunOptions{
 			Workspace: params.CWD,
+			RunDir:    params.RunDir,
 		}
 
 		comp, err := BuildRunComponents(cfg, opts)

--- a/cmd/v100/cmd_gateway.go
+++ b/cmd/v100/cmd_gateway.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func gatewayCmd(cfgPath *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gateway",
+		Short: "Run messaging gateways that drive v100 over ACP",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("use a subcommand, e.g. `gateway telegram`")
+		},
+	}
+
+	cmd.AddCommand(gatewayTelegramCmd(cfgPath))
+	return cmd
+}

--- a/cmd/v100/cmd_gateway_telegram.go
+++ b/cmd/v100/cmd_gateway_telegram.go
@@ -130,7 +130,7 @@ func runTelegramGateway(ctx context.Context, cfgPath *string) error {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 				return nil
 			}
-			fmt.Fprintf(os.Stderr, "telegram gateway poll error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "telegram gateway poll error: %v\n", redactTelegramTokenError(err, gw.token))
 			select {
 			case <-ctx.Done():
 				return nil
@@ -348,7 +348,7 @@ func (g *telegramGateway) pollOnce() error {
 					if g.ctx.Err() != nil {
 						return nil
 					}
-					fmt.Fprintf(os.Stderr, "telegram gateway transcription error: %v\n", terr)
+					fmt.Fprintf(os.Stderr, "telegram gateway transcription error: %v\n", redactTelegramTokenError(terr, g.token))
 					continue
 				}
 				text = strings.TrimSpace(transcript)
@@ -361,7 +361,7 @@ func (g *telegramGateway) pollOnce() error {
 			if g.ctx.Err() != nil {
 				return nil
 			}
-			fmt.Fprintf(os.Stderr, "telegram gateway message error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "telegram gateway message error: %v\n", redactTelegramTokenError(err, g.token))
 			continue
 		}
 	}
@@ -417,6 +417,8 @@ func (g *telegramGateway) handleACPNotification(note acp.Notification) error {
 		if update.Update.Content == nil || strings.TrimSpace(update.Update.Content.Text) == "" {
 			return nil
 		}
+		// Streaming sends from the ACP reader loop; the gateway is currently
+		// single-flight, so a slow Telegram API only delays this in-flight turn.
 		if g.cfg.StreamResponses {
 			return g.sendChunks(state.chatID, splitText(update.Update.Content.Text))
 		}
@@ -512,6 +514,8 @@ func (g *telegramGateway) handleTelegramMessage(chatID int64, text string) error
 }
 
 func (g *telegramGateway) getOrCreateSession(chatID int64) (*telegramGatewaySession, error) {
+	// pollOnce handles updates sequentially today. If per-chat concurrency is
+	// added, this lookup/create path needs singleflight protection.
 	g.sessionsMu.Lock()
 	existing := g.sessionsByChat[chatID]
 	g.sessionsMu.Unlock()
@@ -612,7 +616,7 @@ func (g *telegramGateway) telegramCall(method string, params any, out any) error
 
 	resp, err := g.http.Do(req)
 	if err != nil {
-		return err
+		return redactTelegramTokenError(err, g.token)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -728,7 +732,7 @@ func (g *telegramGateway) downloadAudio(fileID string) (string, error) {
 	}
 	resp, err := g.http.Do(req)
 	if err != nil {
-		return "", err
+		return "", redactTelegramTokenError(err, g.token)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -800,4 +804,16 @@ func splitText(text string) []string {
 		runes = runes[limit:]
 	}
 	return result
+}
+
+func redactTelegramTokenError(err error, token string) error {
+	if err == nil {
+		return nil
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return err
+	}
+	msg := strings.ReplaceAll(err.Error(), token, "<redacted-telegram-token>")
+	return errors.New(msg)
 }

--- a/cmd/v100/cmd_gateway_telegram.go
+++ b/cmd/v100/cmd_gateway_telegram.go
@@ -1,0 +1,803 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tripledoublev/v100/internal/acp"
+	"github.com/tripledoublev/v100/internal/config"
+)
+
+const (
+	telegramAPIBase               = "https://api.telegram.org/bot"
+	telegramFileBase              = "https://api.telegram.org/file/bot"
+	telegramMaxAudioBytes         = 20 << 20 // Telegram bot download cap (~20MB)
+	telegramChunkChars            = 3900
+	telegramBusyMessage           = "Still processing previous request. Please wait for my reply first."
+	telegramDefaultPollTimeoutSec = 30
+	telegramDefaultStatusInterval = 2 * time.Second
+	telegramPollRetryBase         = 1 * time.Second
+	telegramPollRetryMax          = 30 * time.Second
+	// Telegram caps long-poll well under a minute; bound config to sane ranges.
+	telegramMaxPollTimeoutSec    = 50
+	telegramMaxStatusIntervalSec = 300
+	// Bound shutdown so an unresponsive ACP child cannot wedge the gateway.
+	telegramShutdownTimeout = 5 * time.Second
+)
+
+// telegramTokenPattern matches the documented Telegram bot token shape
+// (<numeric bot id>:<secret>) and rejects whitespace or other characters that
+// would be unsafe to splice into a request URL path.
+var telegramTokenPattern = regexp.MustCompile(`^[0-9]+:[A-Za-z0-9_-]+$`)
+
+type telegramClient interface {
+	Call(ctx context.Context, method string, params any, out any) error
+}
+
+func gatewayTelegramCmd(cfgPath *string) *cobra.Command {
+	var once bool
+
+	cmd := &cobra.Command{
+		Use:   "telegram",
+		Short: "Run the Telegram gateway",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if once {
+				return runTelegramGatewayOnce(cmd.Context(), cfgPath)
+			}
+			return runTelegramGateway(cmd.Context(), cfgPath)
+		},
+	}
+
+	cmd.Flags().BoolVar(&once, "once", false, "run one polling cycle and exit")
+	return cmd
+}
+
+type telegramRuntimeConfig struct {
+	PollTimeout     int
+	RunDir          string
+	Workspace       string
+	StreamResponses bool
+	StatusInterval  time.Duration
+	AllowedChatIDs  map[int64]struct{}
+	Provider        string
+}
+
+type telegramGatewaySession struct {
+	chatID     int64
+	sessionID  string
+	inFlight   bool
+	output     strings.Builder
+	lastStatus time.Time
+	mu         sync.Mutex
+}
+
+type telegramGateway struct {
+	ctx        context.Context
+	http       *http.Client
+	token      string
+	cfg        telegramRuntimeConfig
+	cli        telegramClient
+	pollOffset int64
+
+	telegramCallFn func(method string, params any, out any) error
+
+	sessionsByChat  map[int64]*telegramGatewaySession
+	sessionsByAcpID map[string]*telegramGatewaySession
+	sessionsMu      sync.RWMutex
+
+	// acpClosed is closed exactly once when the ACP transport drops, so the
+	// poll loop can exit instead of prompting against a dead client.
+	acpClosed     chan struct{}
+	acpClosedOnce sync.Once
+}
+
+func (g *telegramGateway) markACPClosed() {
+	g.acpClosedOnce.Do(func() {
+		fmt.Fprintln(os.Stderr, "telegram gateway: ACP connection closed; shutting down")
+		close(g.acpClosed)
+	})
+}
+
+func runTelegramGateway(ctx context.Context, cfgPath *string) error {
+	gw, stop, err := setupTelegramGateway(ctx, cfgPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stop() }()
+
+	backoff := telegramPollRetryBase
+	for {
+		select {
+		case <-gw.acpClosed:
+			return fmt.Errorf("telegram gateway: ACP connection closed")
+		default:
+		}
+
+		if err := gw.pollOnce(); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "telegram gateway poll error: %v\n", err)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-gw.acpClosed:
+				return fmt.Errorf("telegram gateway: ACP connection closed")
+			case <-time.After(backoff):
+			}
+			if backoff < telegramPollRetryMax {
+				backoff *= 2
+				if backoff > telegramPollRetryMax {
+					backoff = telegramPollRetryMax
+				}
+			}
+			continue
+		}
+
+		backoff = telegramPollRetryBase
+	}
+}
+
+func runTelegramGatewayOnce(ctx context.Context, cfgPath *string) error {
+	gw, stop, err := setupTelegramGateway(ctx, cfgPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stop() }()
+	return gw.pollOnce()
+}
+
+func setupTelegramGateway(ctx context.Context, cfgPath *string) (*telegramGateway, func() error, error) {
+	cfg, err := loadConfig(*cfgPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	normalizedCfg := normalizeTelegramConfig(cfg.Telegram)
+
+	token := strings.TrimSpace(cfg.Telegram.BotToken)
+	if token == "" && strings.TrimSpace(cfg.Telegram.BotTokenEnv) != "" {
+		token = strings.TrimSpace(os.Getenv(cfg.Telegram.BotTokenEnv))
+	}
+	if !cfg.Telegram.Enabled || token == "" {
+		return nil, nil, fmt.Errorf("telegram gateway is disabled or telegram token is missing")
+	}
+	if !telegramTokenPattern.MatchString(token) {
+		return nil, nil, fmt.Errorf("telegram bot token is malformed; expected <bot_id>:<secret>")
+	}
+
+	gw := &telegramGateway{
+		ctx:             ctx,
+		http:            &http.Client{Timeout: telegramHTTPClientTimeout(normalizedCfg.PollTimeout)},
+		token:           token,
+		cfg:             normalizedCfg,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+		telegramCallFn:  nil,
+		acpClosed:       make(chan struct{}),
+	}
+
+	cli, stopServer, err := runACPServer(ctx, *cfgPath, normalizedCfg.Provider, func(note acp.Notification) {
+		_ = gw.handleACPNotification(note)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	gw.cli = cli
+	gw.telegramCallFn = gw.telegramCall
+
+	return gw, func() error {
+		_ = gw.closeAllSessions()
+		return stopServer()
+	}, nil
+}
+
+func normalizeTelegramConfig(cfg config.TelegramConfig) telegramRuntimeConfig {
+	pollTimeout := cfg.PollTimeoutSec
+	if pollTimeout <= 0 {
+		pollTimeout = telegramDefaultPollTimeoutSec
+	}
+	if pollTimeout > telegramMaxPollTimeoutSec {
+		pollTimeout = telegramMaxPollTimeoutSec
+	}
+	statusIntervalSec := cfg.StatusIntervalSec
+	if statusIntervalSec > telegramMaxStatusIntervalSec {
+		statusIntervalSec = telegramMaxStatusIntervalSec
+	}
+	statusInterval := time.Duration(statusIntervalSec) * time.Second
+	if statusInterval <= 0 {
+		statusInterval = telegramDefaultStatusInterval
+	}
+
+	allowedChatIDs := make(map[int64]struct{}, len(cfg.AllowedChatIDs))
+	for _, chatID := range cfg.AllowedChatIDs {
+		if chatID != 0 {
+			allowedChatIDs[chatID] = struct{}{}
+		}
+	}
+
+	return telegramRuntimeConfig{
+		PollTimeout:     pollTimeout,
+		RunDir:          strings.TrimSpace(cfg.RunDir),
+		Workspace:       strings.TrimSpace(cfg.Workspace),
+		StreamResponses: cfg.StreamResponses,
+		StatusInterval:  statusInterval,
+		AllowedChatIDs:  allowedChatIDs,
+		Provider:        strings.TrimSpace(cfg.Provider),
+	}
+}
+
+func telegramHTTPClientTimeout(pollTimeoutSeconds int) time.Duration {
+	if pollTimeoutSeconds <= 0 {
+		return time.Duration(telegramDefaultPollTimeoutSec+10) * time.Second
+	}
+	return time.Duration(pollTimeoutSeconds+10) * time.Second
+}
+
+func runACPServer(ctx context.Context, cfgPath, provider string, onNotification func(acp.Notification)) (*acp.Client, func() error, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve executable: %w", err)
+	}
+	exe, _ = filepath.EvalSymlinks(exe)
+
+	args := []string{"acp"}
+	if strings.TrimSpace(cfgPath) != "" {
+		args = append(args, "--config", cfgPath)
+	}
+	if strings.TrimSpace(provider) != "" {
+		args = append(args, "--provider", provider)
+	}
+
+	child := exec.CommandContext(ctx, exe, args...)
+	child.Stderr = os.Stderr
+
+	stdin, err := child.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("acp stdin: %w", err)
+	}
+	stdout, err := child.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, nil, fmt.Errorf("acp stdout: %w", err)
+	}
+
+	if err := child.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, nil, fmt.Errorf("start acp process: %w", err)
+	}
+
+	client := acp.NewClient(stdout, stdin, onNotification)
+	client.StartLaunch()
+
+	initCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := initializeACP(initCtx, client); err != nil {
+		_ = child.Process.Kill()
+		_ = child.Wait()
+		return nil, nil, fmt.Errorf("initialize acp server: %w", err)
+	}
+
+	stop := func() error {
+		if ctx.Err() == nil {
+			finalizeCtx, cancel := context.WithTimeout(context.Background(), telegramShutdownTimeout)
+			_ = client.Call(finalizeCtx, acp.MethodFinalize, acp.FinalizeParams{Reason: "gateway_exit"}, nil)
+			cancel()
+		}
+		_ = child.Process.Kill()
+		return child.Wait()
+	}
+
+	return client, stop, nil
+}
+
+func initializeACP(ctx context.Context, cli *acp.Client) error {
+	var initRes acp.InitializeResult
+	return cli.Call(ctx, acp.MethodInitialize, acp.InitializeParams{
+		ProtocolVersion: acp.ProtocolVersion,
+		ClientInfo: acp.ClientInfo{
+			Name:    "v100-gateway",
+			Version: "dev",
+		},
+		ClientCapabilities: acp.ClientCapabilities{},
+	}, &initRes)
+}
+
+func (g *telegramGateway) pollOnce() error {
+	// pollOnce is intentionally single-flight: updates are handled sequentially.
+	// Concurrency per chat is not supported yet.
+	updates, err := g.fetchUpdates()
+	if err != nil {
+		return err
+	}
+
+	for _, update := range updates {
+		if update.UpdateID < g.pollOffset {
+			continue
+		}
+		g.pollOffset = update.UpdateID + 1
+
+		if update.Message == nil {
+			continue
+		}
+		chat := update.Message.Chat
+		// Gate on the allowlist before any expensive work (downloads, STT).
+		if !g.chatAllowed(chat.ID) {
+			continue
+		}
+
+		text := strings.TrimSpace(update.Message.Text)
+		if text == "" {
+			if audio := update.Message.audioFile(); audio != nil {
+				transcript, terr := g.transcribeVoice(chat.ID, audio)
+				if terr != nil {
+					if g.ctx.Err() != nil {
+						return nil
+					}
+					fmt.Fprintf(os.Stderr, "telegram gateway transcription error: %v\n", terr)
+					continue
+				}
+				text = strings.TrimSpace(transcript)
+			}
+		}
+		if text == "" {
+			continue
+		}
+		if err := g.handleTelegramMessage(chat.ID, text); err != nil {
+			if g.ctx.Err() != nil {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "telegram gateway message error: %v\n", err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (g *telegramGateway) fetchUpdates() ([]telegramUpdate, error) {
+	params := map[string]any{
+		"timeout":         g.cfg.PollTimeout,
+		"allowed_updates": []string{"message"},
+	}
+	if g.pollOffset > 0 {
+		params["offset"] = g.pollOffset
+	}
+
+	var updates []telegramUpdate
+	if err := g.telegramCall("getUpdates", params, &updates); err != nil {
+		return nil, err
+	}
+
+	return updates, nil
+}
+
+func (g *telegramGateway) handleACPNotification(note acp.Notification) error {
+	if note.Method == acp.MethodConnectionClosed {
+		g.markACPClosed()
+		return nil
+	}
+	if note.Method != acp.MethodSessionUpdate {
+		return nil
+	}
+
+	var update acp.SessionUpdateParams
+	if err := json.Unmarshal(note.Params, &update); err != nil {
+		fmt.Fprintf(os.Stderr, "telegram gateway: dropping malformed %s payload: %v\n", note.Method, err)
+		return nil
+	}
+
+	if strings.TrimSpace(update.SessionID) == "" {
+		return nil
+	}
+
+	g.sessionsMu.RLock()
+	state := g.sessionsByAcpID[update.SessionID]
+	g.sessionsMu.RUnlock()
+	if state == nil {
+		return nil
+	}
+
+	switch update.Update.Type {
+	case "agent_message_chunk":
+		if update.Update.Content == nil || strings.TrimSpace(update.Update.Content.Text) == "" {
+			return nil
+		}
+		if g.cfg.StreamResponses {
+			return g.sendChunks(state.chatID, splitText(update.Update.Content.Text))
+		}
+		state.mu.Lock()
+		state.output.WriteString(update.Update.Content.Text)
+		state.mu.Unlock()
+	case "run_status_update":
+		if update.Update.Status != "in_progress" {
+			return nil
+		}
+		state.mu.Lock()
+		since := time.Since(state.lastStatus)
+		state.mu.Unlock()
+		if since < g.cfg.StatusInterval {
+			return nil
+		}
+		if err := g.sendChatAction(state.chatID); err == nil {
+			state.mu.Lock()
+			state.lastStatus = time.Now()
+			state.mu.Unlock()
+		}
+	case "run_error":
+		if strings.TrimSpace(update.Update.Status) == "failed" {
+			return g.sendChunkToChat(state.chatID, "Run failed. Check the run log for details.")
+		}
+	}
+
+	return nil
+}
+
+// chatAllowed reports whether the gateway should act on messages from chatID.
+// An empty allowlist allows all chats.
+func (g *telegramGateway) chatAllowed(chatID int64) bool {
+	if len(g.cfg.AllowedChatIDs) == 0 {
+		return true
+	}
+	_, ok := g.cfg.AllowedChatIDs[chatID]
+	return ok
+}
+
+func (g *telegramGateway) handleTelegramMessage(chatID int64, text string) error {
+	if !g.chatAllowed(chatID) {
+		return nil
+	}
+
+	state, err := g.getOrCreateSession(chatID)
+	if err != nil {
+		return err
+	}
+
+	state.mu.Lock()
+	if state.inFlight {
+		state.mu.Unlock()
+		return g.sendChunks(chatID, []string{telegramBusyMessage})
+	}
+	state.inFlight = true
+	state.output.Reset()
+	state.mu.Unlock()
+
+	defer func() {
+		state.mu.Lock()
+		state.inFlight = false
+		state.mu.Unlock()
+	}()
+
+	prompt := []acp.ContentBlock{{Type: "text", Text: text}}
+	var promptRes acp.SessionPromptResult
+	if err := g.cli.Call(g.ctx, acp.MethodSessionPrompt, acp.SessionPromptParams{
+		SessionID: state.sessionID,
+		Prompt:    prompt,
+	}, &promptRes); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return g.sendChunks(chatID, []string{fmt.Sprintf("v100 error: %v", err)})
+	}
+
+	if g.cfg.StreamResponses {
+		if promptRes.StopReason != "" && promptRes.StopReason != "end_turn" {
+			return g.sendChunks(chatID, []string{fmt.Sprintf("Stopped: %s", promptRes.StopReason)})
+		}
+		return nil
+	}
+
+	state.mu.Lock()
+	response := strings.TrimSpace(state.output.String())
+	state.output.Reset()
+	state.mu.Unlock()
+	if response == "" {
+		response = "(no response)"
+	}
+	return g.sendChunks(chatID, splitText(response))
+}
+
+func (g *telegramGateway) getOrCreateSession(chatID int64) (*telegramGatewaySession, error) {
+	g.sessionsMu.Lock()
+	existing := g.sessionsByChat[chatID]
+	g.sessionsMu.Unlock()
+	if existing != nil {
+		return existing, nil
+	}
+
+	sessionID := fmt.Sprintf("tg-%d", chatID)
+	params := acp.SessionNewParams{
+		SessionID: sessionID,
+		CWD:       g.cfg.Workspace,
+		RunDir:    g.cfg.RunDir,
+	}
+
+	var res acp.SessionNewResult
+	if err := g.cli.Call(g.ctx, acp.MethodSessionNew, params, &res); err != nil {
+		return nil, fmt.Errorf("create acp session: %w", err)
+	}
+	if strings.TrimSpace(res.SessionID) != "" {
+		sessionID = strings.TrimSpace(res.SessionID)
+	}
+
+	state := &telegramGatewaySession{chatID: chatID, sessionID: sessionID}
+	g.sessionsMu.Lock()
+	g.sessionsByChat[chatID] = state
+	g.sessionsByAcpID[sessionID] = state
+	g.sessionsMu.Unlock()
+
+	return state, nil
+}
+
+func (g *telegramGateway) closeAllSessions() error {
+	g.sessionsMu.RLock()
+	states := make([]*telegramGatewaySession, 0, len(g.sessionsByAcpID))
+	for _, state := range g.sessionsByAcpID {
+		states = append(states, state)
+	}
+	g.sessionsMu.RUnlock()
+
+	for _, state := range states {
+		state.mu.Lock()
+		sessionID := state.sessionID
+		state.mu.Unlock()
+		if sessionID == "" {
+			continue
+		}
+		closeCtx, cancel := context.WithTimeout(context.Background(), telegramShutdownTimeout)
+		_ = g.cli.Call(closeCtx, acp.MethodSessionClose, struct {
+			SessionID string `json:"sessionId"`
+		}{SessionID: sessionID}, nil)
+		cancel()
+	}
+
+	return nil
+}
+
+func (g *telegramGateway) sendChunks(chatID int64, chunks []string) error {
+	if g.telegramCallFn == nil {
+		return fmt.Errorf("telegram call function is not configured")
+	}
+	for _, chunk := range chunks {
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		if err := g.telegramCallFn("sendMessage", map[string]any{
+			"chat_id": chatID,
+			"text":    chunk,
+		}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *telegramGateway) sendChunkToChat(chatID int64, chunk string) error {
+	return g.sendChunks(chatID, splitText(chunk))
+}
+
+func (g *telegramGateway) sendChatAction(chatID int64) error {
+	if g.telegramCallFn == nil {
+		return fmt.Errorf("telegram call function is not configured")
+	}
+	return g.telegramCallFn("sendChatAction", map[string]any{"chat_id": chatID, "action": "typing"}, nil)
+}
+
+func (g *telegramGateway) telegramCall(method string, params any, out any) error {
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(g.ctx, http.MethodPost, telegramAPIBase+g.token+"/"+method, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("telegram %s failed: status=%d body=%q", method, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	var envelope struct {
+		OK          bool            `json:"ok"`
+		Result      json.RawMessage `json:"result"`
+		ErrorCode   int             `json:"error_code"`
+		Description string          `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return err
+	}
+	if !envelope.OK {
+		return fmt.Errorf("telegram %s failed: code=%d desc=%s", method, envelope.ErrorCode, envelope.Description)
+	}
+	if out != nil {
+		if err := json.Unmarshal(envelope.Result, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type telegramUpdate struct {
+	UpdateID int64            `json:"update_id"`
+	Message  *telegramMessage `json:"message"`
+}
+
+type telegramMessage struct {
+	Text  string        `json:"text"`
+	Voice *telegramFile `json:"voice"`
+	Audio *telegramFile `json:"audio"`
+	Chat  telegramChat  `json:"chat"`
+}
+
+// audioFile returns the voice note or audio attachment on the message, if any,
+// preferring a voice note.
+func (m *telegramMessage) audioFile() *telegramFile {
+	if m == nil {
+		return nil
+	}
+	if m.Voice != nil && strings.TrimSpace(m.Voice.FileID) != "" {
+		return m.Voice
+	}
+	if m.Audio != nil && strings.TrimSpace(m.Audio.FileID) != "" {
+		return m.Audio
+	}
+	return nil
+}
+
+type telegramFile struct {
+	FileID   string `json:"file_id"`
+	MimeType string `json:"mime_type"`
+	Duration int    `json:"duration"`
+}
+
+type telegramChat struct {
+	ID int64 `json:"id"`
+}
+
+// errTranscriberUnavailable signals that no transcription command is configured
+// or installed, so voice messages cannot be handled.
+var errTranscriberUnavailable = errors.New("no transcription command configured")
+
+// transcribeAudioFile runs the configured speech-to-text shim on an audio file
+// and returns the transcript. The shim is `$V100_TRANSCRIBE_CMD <file>` (default
+// binary: v100-transcribe), mirroring the v100-listen / v100-tts shims: file
+// path in, transcript on stdout. When V100_TRANSCRIBE_CMD contains arguments or
+// a pipe, the file path is passed safely as $1 via `sh -c`.
+func transcribeAudioFile(ctx context.Context, path string) (string, error) {
+	raw := strings.TrimSpace(os.Getenv("V100_TRANSCRIBE_CMD"))
+
+	var cmd *exec.Cmd
+	if raw == "" {
+		if _, err := exec.LookPath("v100-transcribe"); err != nil {
+			return "", errTranscriberUnavailable
+		}
+		cmd = exec.CommandContext(ctx, "v100-transcribe", path)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", raw+` "$1"`, "sh", path)
+	}
+
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("transcribe: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// downloadAudio resolves a Telegram file_id to a local temp file, returning its
+// path. The caller is responsible for removing it.
+func (g *telegramGateway) downloadAudio(fileID string) (string, error) {
+	var info struct {
+		FilePath string `json:"file_path"`
+	}
+	if err := g.telegramCall("getFile", map[string]any{"file_id": fileID}, &info); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(info.FilePath) == "" {
+		return "", fmt.Errorf("telegram getFile returned empty file_path")
+	}
+
+	req, err := http.NewRequestWithContext(g.ctx, http.MethodGet, telegramFileBase+g.token+"/"+info.FilePath, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := g.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("telegram file download failed: status=%d", resp.StatusCode)
+	}
+
+	ext := filepath.Ext(info.FilePath)
+	if ext == "" {
+		ext = ".oga"
+	}
+	f, err := os.CreateTemp("", "tg-voice-*"+ext)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(f, io.LimitReader(resp.Body, telegramMaxAudioBytes)); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// transcribeVoice downloads and transcribes a voice/audio attachment, replying
+// to the chat with a clear message on any failure. It returns the transcript, or
+// an empty string when nothing actionable was produced.
+func (g *telegramGateway) transcribeVoice(chatID int64, file *telegramFile) (string, error) {
+	path, err := g.downloadAudio(file.FileID)
+	if err != nil {
+		_ = g.sendChunks(chatID, []string{"Couldn't download your voice message."})
+		return "", err
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	transcript, err := transcribeAudioFile(g.ctx, path)
+	if err != nil {
+		if errors.Is(err, errTranscriberUnavailable) {
+			_ = g.sendChunks(chatID, []string{"Voice transcription isn't set up on this gateway. Please send text, or configure V100_TRANSCRIBE_CMD."})
+		} else {
+			_ = g.sendChunks(chatID, []string{"Sorry, I couldn't transcribe that audio."})
+		}
+		return "", err
+	}
+	if transcript == "" {
+		_ = g.sendChunks(chatID, []string{"I couldn't make out any speech in that message."})
+		return "", nil
+	}
+
+	// Echo what was understood so the user can catch mis-transcriptions.
+	_ = g.sendChunks(chatID, []string{"🎤 " + transcript})
+	return transcript, nil
+}
+
+func splitText(text string) []string {
+	if text == "" {
+		return nil
+	}
+	result := make([]string, 0)
+	runes := []rune(text)
+	for len(runes) > 0 {
+		limit := telegramChunkChars
+		if len(runes) < limit {
+			limit = len(runes)
+		}
+		result = append(result, string(runes[:limit]))
+		runes = runes[limit:]
+	}
+	return result
+}

--- a/cmd/v100/cmd_gateway_telegram_test.go
+++ b/cmd/v100/cmd_gateway_telegram_test.go
@@ -263,6 +263,33 @@ type telegramVoiceRoundTripper struct {
 	downloadN int
 }
 
+type telegramURLLeakRoundTripper struct {
+	token string
+}
+
+func (r telegramURLLeakRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("dial failed for " + req.URL.String())
+}
+
+type telegramFileDownloadLeakRoundTripper struct {
+	token string
+}
+
+func (r telegramFileDownloadLeakRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "/getFile") {
+		body, _ := json.Marshal(struct {
+			OK     bool `json:"ok"`
+			Result struct {
+				FilePath string `json:"file_path"`
+			} `json:"result"`
+		}{OK: true, Result: struct {
+			FilePath string `json:"file_path"`
+		}{FilePath: "voice/file_1.oga"}})
+		return jsonResp(body), nil
+	}
+	return nil, errors.New("download failed for " + req.URL.String())
+}
+
 func jsonResp(body []byte) *http.Response {
 	return &http.Response{
 		StatusCode: 200,
@@ -328,6 +355,46 @@ func TestTelegramMessageAudioFilePrefersVoice(t *testing.T) {
 
 	if (&telegramMessage{Text: "hi"}).audioFile() != nil {
 		t.Fatal("text-only message should have no audio file")
+	}
+}
+
+func TestTelegramCallRedactsTokenFromTransportErrors(t *testing.T) {
+	token := "123456789:AASecretToken"
+	gw := &telegramGateway{
+		ctx:   context.Background(),
+		http:  &http.Client{Transport: telegramURLLeakRoundTripper{token: token}},
+		token: token,
+	}
+
+	err := gw.telegramCall("getUpdates", map[string]any{"timeout": 1}, nil)
+	if err == nil {
+		t.Fatal("expected telegramCall to return transport error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("transport error leaked token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "<redacted-telegram-token>") {
+		t.Fatalf("transport error did not include redaction marker: %v", err)
+	}
+}
+
+func TestDownloadAudioRedactsTokenFromTransportErrors(t *testing.T) {
+	token := "123456789:AASecretToken"
+	gw := &telegramGateway{
+		ctx:   context.Background(),
+		http:  &http.Client{Transport: telegramFileDownloadLeakRoundTripper{token: token}},
+		token: token,
+	}
+
+	_, err := gw.downloadAudio("voice-1")
+	if err == nil {
+		t.Fatal("expected downloadAudio to return transport error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("download error leaked token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "<redacted-telegram-token>") {
+		t.Fatalf("download error did not include redaction marker: %v", err)
 	}
 }
 

--- a/cmd/v100/cmd_gateway_telegram_test.go
+++ b/cmd/v100/cmd_gateway_telegram_test.go
@@ -1,0 +1,735 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tripledoublev/v100/internal/acp"
+	"github.com/tripledoublev/v100/internal/config"
+)
+
+func TestNormalizeTelegramConfigDefaults(t *testing.T) {
+	cfg := config.TelegramConfig{
+		BotToken:          "  token  ",
+		PollTimeoutSec:    0,
+		RunDir:            "  /tmp/v100-run  ",
+		Workspace:         "  /tmp/v100-work  ",
+		StreamResponses:   true,
+		StatusIntervalSec: 0,
+	}
+
+	got := normalizeTelegramConfig(cfg)
+	if got.PollTimeout != telegramDefaultPollTimeoutSec {
+		t.Fatalf("poll timeout = %d, want %d", got.PollTimeout, telegramDefaultPollTimeoutSec)
+	}
+	if got.RunDir != "/tmp/v100-run" {
+		t.Fatalf("run dir = %q, want /tmp/v100-run", got.RunDir)
+	}
+	if got.Workspace != "/tmp/v100-work" {
+		t.Fatalf("workspace = %q, want /tmp/v100-work", got.Workspace)
+	}
+	if got.StatusInterval != telegramDefaultStatusInterval {
+		t.Fatalf("status interval = %s, want %s", got.StatusInterval, telegramDefaultStatusInterval)
+	}
+	if !got.StreamResponses {
+		t.Fatal("expected stream responses to stay enabled")
+	}
+}
+
+func TestSplitTextSplitsRunesAndBoundedChunks(t *testing.T) {
+	text := "😀" + "x"
+	chunks := splitText(text)
+	if len(chunks) != 1 {
+		t.Fatalf("splitText produced %d chunks, want 1", len(chunks))
+	}
+	if chunks[0] != text {
+		t.Fatalf("splitText changed text: %q", chunks[0])
+	}
+
+	longText := strings.Repeat("a", telegramChunkChars+17)
+	chunks = splitText(longText)
+	if len(chunks) != 2 {
+		t.Fatalf("splitText produced %d chunks, want 2", len(chunks))
+	}
+	if len([]rune(chunks[0])) != telegramChunkChars {
+		t.Fatalf("first chunk length = %d, want %d", len([]rune(chunks[0])), telegramChunkChars)
+	}
+	if len([]rune(chunks[1])) != 17 {
+		t.Fatalf("second chunk length = %d, want 17", len([]rune(chunks[1])))
+	}
+}
+
+func TestNormalizeTelegramConfigCapturesAllowedChats(t *testing.T) {
+	cfg := config.TelegramConfig{
+		PollTimeoutSec:    40,
+		StatusIntervalSec: 3,
+		AllowedChatIDs:    []int64{111, 222, 111, 0},
+	}
+
+	got := normalizeTelegramConfig(cfg)
+	if got.PollTimeout != 40 {
+		t.Fatalf("poll timeout = %d, want %d", got.PollTimeout, 40)
+	}
+	if got.StatusInterval != 3*time.Second {
+		t.Fatalf("status interval = %s, want %s", got.StatusInterval, 3*time.Second)
+	}
+	if got.AllowedChatIDs == nil {
+		t.Fatal("expected allowed chat IDs map")
+	}
+	if len(got.AllowedChatIDs) != 2 {
+		t.Fatalf("allowed chat ID count = %d, want %d", len(got.AllowedChatIDs), 2)
+	}
+	if _, ok := got.AllowedChatIDs[111]; !ok {
+		t.Fatalf("expected allowed chat id 111")
+	}
+	if _, ok := got.AllowedChatIDs[222]; !ok {
+		t.Fatalf("expected allowed chat id 222")
+	}
+}
+
+type telegramTestClient struct {
+	callCount  atomic.Int32
+	getUpdates []telegramUpdate
+}
+
+func (c *telegramTestClient) Call(_ context.Context, method string, _ any, out any) error {
+	c.callCount.Add(1)
+	switch method {
+	case acp.MethodSessionNew:
+		if params, ok := out.(*acp.SessionNewResult); ok {
+			params.SessionID = "tg-session"
+		}
+	case acp.MethodSessionPrompt:
+		if res, ok := out.(*acp.SessionPromptResult); ok {
+			res.StopReason = "end_turn"
+		}
+	case "getUpdates":
+		if out != nil {
+			if updates, ok := out.(*[]telegramUpdate); ok {
+				*updates = c.getUpdates
+			}
+		}
+	}
+	return nil
+}
+
+type telegramSessionCaptureClient struct {
+	telegramTestClient
+	lastNew acp.SessionNewParams
+}
+
+func (c *telegramSessionCaptureClient) Call(ctx context.Context, method string, params any, out any) error {
+	if method == acp.MethodSessionNew {
+		if p, ok := params.(acp.SessionNewParams); ok {
+			c.lastNew = p
+		}
+	}
+	return c.telegramTestClient.Call(ctx, method, params, out)
+}
+
+func TestGetOrCreateSessionKeepsRunDirSeparateFromWorkspace(t *testing.T) {
+	client := &telegramSessionCaptureClient{}
+	gw := &telegramGateway{
+		ctx: context.Background(),
+		cfg: telegramRuntimeConfig{
+			RunDir:    "/tmp/v100-runs",
+			Workspace: "/tmp/project",
+		},
+		cli:             client,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if _, err := gw.getOrCreateSession(42); err != nil {
+		t.Fatalf("getOrCreateSession returned error: %v", err)
+	}
+	if client.lastNew.RunDir != "/tmp/v100-runs" {
+		t.Fatalf("session run dir = %q, want /tmp/v100-runs", client.lastNew.RunDir)
+	}
+	if client.lastNew.CWD != "/tmp/project" {
+		t.Fatalf("session cwd = %q, want /tmp/project", client.lastNew.CWD)
+	}
+
+	client = &telegramSessionCaptureClient{}
+	gw = &telegramGateway{
+		ctx: context.Background(),
+		cfg: telegramRuntimeConfig{
+			RunDir: "/tmp/v100-runs",
+		},
+		cli:             client,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if _, err := gw.getOrCreateSession(43); err != nil {
+		t.Fatalf("getOrCreateSession returned error: %v", err)
+	}
+	if client.lastNew.RunDir != "/tmp/v100-runs" {
+		t.Fatalf("session run dir = %q, want /tmp/v100-runs", client.lastNew.RunDir)
+	}
+	if client.lastNew.CWD != "" {
+		t.Fatalf("session cwd = %q, want empty", client.lastNew.CWD)
+	}
+}
+
+type telegramCallCapture struct {
+	mu      sync.Mutex
+	methods []string
+	texts   []string
+}
+
+func (c *telegramCallCapture) call(method string, params any, _ any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.methods = append(c.methods, method)
+	if method == "sendMessage" {
+		if m, ok := params.(map[string]any); ok {
+			if text, ok := m["text"].(string); ok {
+				c.texts = append(c.texts, text)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *telegramCallCapture) methodsCalled() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.methods)
+}
+
+func (c *telegramCallCapture) sentTexts() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.texts))
+	copy(out, c.texts)
+	return out
+}
+
+type telegramUpdateRoundTripper struct {
+	mu      sync.Mutex
+	updates []telegramUpdate
+	calls   int
+}
+
+func (r *telegramUpdateRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+
+	payload := struct {
+		OK     bool             `json:"ok"`
+		Result []telegramUpdate `json:"result"`
+	}{
+		OK:     true,
+		Result: r.updates,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (r *telegramUpdateRoundTripper) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// telegramVoiceRoundTripper routes by URL path so a voice message can flow
+// through getUpdates -> getFile -> file download in one fake transport.
+type telegramVoiceRoundTripper struct {
+	mu        sync.Mutex
+	updates   []telegramUpdate
+	filePath  string
+	audio     []byte
+	getFileN  int
+	downloadN int
+}
+
+func jsonResp(body []byte) *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func (r *telegramVoiceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	p := req.URL.Path
+	switch {
+	case strings.HasSuffix(p, "/getUpdates"):
+		body, _ := json.Marshal(struct {
+			OK     bool             `json:"ok"`
+			Result []telegramUpdate `json:"result"`
+		}{OK: true, Result: r.updates})
+		return jsonResp(body), nil
+	case strings.HasSuffix(p, "/getFile"):
+		r.mu.Lock()
+		r.getFileN++
+		r.mu.Unlock()
+		body, _ := json.Marshal(struct {
+			OK     bool `json:"ok"`
+			Result struct {
+				FilePath string `json:"file_path"`
+			} `json:"result"`
+		}{OK: true, Result: struct {
+			FilePath string `json:"file_path"`
+		}{FilePath: r.filePath}})
+		return jsonResp(body), nil
+	case strings.Contains(p, "/file/bot"):
+		r.mu.Lock()
+		r.downloadN++
+		r.mu.Unlock()
+		return jsonResp(r.audio), nil
+	default: // sendMessage / sendChatAction
+		body, _ := json.Marshal(struct {
+			OK     bool `json:"ok"`
+			Result bool `json:"result"`
+		}{OK: true, Result: true})
+		return jsonResp(body), nil
+	}
+}
+
+func TestTelegramMessageAudioFilePrefersVoice(t *testing.T) {
+	m := &telegramMessage{
+		Voice: &telegramFile{FileID: "voice-1"},
+		Audio: &telegramFile{FileID: "audio-1"},
+	}
+	if got := m.audioFile(); got == nil || got.FileID != "voice-1" {
+		t.Fatalf("expected voice to win, got %+v", got)
+	}
+
+	m = &telegramMessage{Audio: &telegramFile{FileID: "audio-1"}}
+	if got := m.audioFile(); got == nil || got.FileID != "audio-1" {
+		t.Fatalf("expected audio fallback, got %+v", got)
+	}
+
+	m = &telegramMessage{Voice: &telegramFile{FileID: "   "}}
+	if got := m.audioFile(); got != nil {
+		t.Fatalf("expected blank file_id to be ignored, got %+v", got)
+	}
+
+	if (&telegramMessage{Text: "hi"}).audioFile() != nil {
+		t.Fatal("text-only message should have no audio file")
+	}
+}
+
+func TestTranscribeAudioFileUnavailableWithoutCommand(t *testing.T) {
+	t.Setenv("V100_TRANSCRIBE_CMD", "")
+	t.Setenv("PATH", t.TempDir()) // ensure v100-transcribe is not resolvable
+
+	_, err := transcribeAudioFile(context.Background(), "/tmp/whatever.oga")
+	if !errors.Is(err, errTranscriberUnavailable) {
+		t.Fatalf("expected errTranscriberUnavailable, got %v", err)
+	}
+}
+
+func TestTranscribeAudioFileRunsConfiguredCommand(t *testing.T) {
+	// printf ignores the appended file-path arg (no format directives), so the
+	// transcript is exactly the literal.
+	t.Setenv("V100_TRANSCRIBE_CMD", "printf 'spoken words'")
+
+	got, err := transcribeAudioFile(context.Background(), "/tmp/whatever.oga")
+	if err != nil {
+		t.Fatalf("transcribeAudioFile returned error: %v", err)
+	}
+	if got != "spoken words" {
+		t.Fatalf("transcript = %q, want %q", got, "spoken words")
+	}
+}
+
+func TestPollOnceTranscribesVoiceMessage(t *testing.T) {
+	t.Setenv("V100_TRANSCRIBE_CMD", "printf 'turn on the lights'")
+
+	rt := &telegramVoiceRoundTripper{
+		updates: []telegramUpdate{{
+			UpdateID: 7001,
+			Message: &telegramMessage{
+				Voice: &telegramFile{FileID: "voice-abc"},
+				Chat:  telegramChat{ID: 123},
+			},
+		}},
+		filePath: "voice/file_1.oga",
+		audio:    []byte("fake-ogg-bytes"),
+	}
+	client := &telegramTestClient{}
+	callCapture := &telegramCallCapture{}
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		cfg:             telegramRuntimeConfig{AllowedChatIDs: map[int64]struct{}{123: {}}, PollTimeout: 1},
+		http:            &http.Client{Transport: rt},
+		token:           "123:test",
+		cli:             client,
+		telegramCallFn:  callCapture.call,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if err := gw.pollOnce(); err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+
+	if rt.getFileN != 1 || rt.downloadN != 1 {
+		t.Fatalf("expected one getFile + one download, got getFile=%d download=%d", rt.getFileN, rt.downloadN)
+	}
+	// SessionNew + SessionPrompt means the transcript reached the agent.
+	if client.callCount.Load() < 2 {
+		t.Fatalf("expected ACP session+prompt calls, got %d", client.callCount.Load())
+	}
+	foundEcho := false
+	for _, txt := range callCapture.sentTexts() {
+		if strings.Contains(txt, "turn on the lights") {
+			foundEcho = true
+		}
+	}
+	if !foundEcho {
+		t.Fatalf("expected transcript echo in sent messages, got %v", callCapture.sentTexts())
+	}
+}
+
+func TestPollOnceVoiceWithoutTranscriberReplies(t *testing.T) {
+	t.Setenv("V100_TRANSCRIBE_CMD", "")
+	t.Setenv("PATH", t.TempDir())
+
+	rt := &telegramVoiceRoundTripper{
+		updates: []telegramUpdate{{
+			UpdateID: 8001,
+			Message: &telegramMessage{
+				Voice: &telegramFile{FileID: "voice-xyz"},
+				Chat:  telegramChat{ID: 123},
+			},
+		}},
+		filePath: "voice/file_2.oga",
+		audio:    []byte("fake"),
+	}
+	client := &telegramTestClient{}
+	callCapture := &telegramCallCapture{}
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		cfg:             telegramRuntimeConfig{AllowedChatIDs: map[int64]struct{}{123: {}}, PollTimeout: 1},
+		http:            &http.Client{Transport: rt},
+		token:           "123:test",
+		cli:             client,
+		telegramCallFn:  callCapture.call,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if err := gw.pollOnce(); err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+
+	if client.callCount.Load() != 0 {
+		t.Fatalf("expected no ACP calls when transcription is unavailable, got %d", client.callCount.Load())
+	}
+	foundNotice := false
+	for _, txt := range callCapture.sentTexts() {
+		if strings.Contains(txt, "isn't set up") {
+			foundNotice = true
+		}
+	}
+	if !foundNotice {
+		t.Fatalf("expected 'not set up' notice, got %v", callCapture.sentTexts())
+	}
+}
+
+func TestHandleTelegramMessageRejectsDisallowedChat(t *testing.T) {
+	client := &telegramTestClient{}
+	gw := &telegramGateway{
+		ctx: context.Background(),
+		cfg: telegramRuntimeConfig{
+			AllowedChatIDs: map[int64]struct{}{
+				123: {},
+			},
+			StreamResponses: true,
+			StatusInterval:  time.Second,
+		},
+		cli:             client,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if err := gw.handleTelegramMessage(999, "should be ignored"); err != nil {
+		t.Fatalf("handleTelegramMessage returned error: %v", err)
+	}
+	if client.callCount.Load() != 0 {
+		t.Fatalf("expected telegram client to be untouched for disallowed chat, got %d calls", client.callCount.Load())
+	}
+}
+
+func TestPollOnceRejectsDisallowedChat(t *testing.T) {
+	client := &telegramTestClient{
+		getUpdates: []telegramUpdate{
+			{
+				UpdateID: 9001,
+				Message: &telegramMessage{
+					Text: "should be ignored",
+					Chat: telegramChat{ID: 999},
+				},
+			},
+		},
+	}
+
+	rt := &telegramUpdateRoundTripper{
+		updates: client.getUpdates,
+	}
+	callCapture := &telegramCallCapture{}
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		cfg:             telegramRuntimeConfig{AllowedChatIDs: map[int64]struct{}{123: {}}, PollTimeout: 1, StreamResponses: true},
+		http:            &http.Client{Transport: rt},
+		token:           "test",
+		cli:             client,
+		telegramCallFn:  callCapture.call,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	if err := gw.pollOnce(); err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+	if client.callCount.Load() != 0 {
+		t.Fatalf("expected disallowed chat to skip ACP calls, got %d", client.callCount.Load())
+	}
+	if callCapture.methodsCalled() != 0 {
+		t.Fatalf("expected no Telegram send methods to be called, got %d", callCapture.methodsCalled())
+	}
+	if rt.callCount() != 1 {
+		t.Fatalf("expected one getUpdates request, got %d", rt.callCount())
+	}
+}
+
+func TestHandleACPNotificationRunErrorNotifiesInNonStreamingMode(t *testing.T) {
+	callCapture := &telegramCallCapture{}
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		cfg:             telegramRuntimeConfig{StreamResponses: false},
+		telegramCallFn:  callCapture.call,
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+	state := &telegramGatewaySession{chatID: 42, sessionID: "session-42"}
+	gw.sessionsByChat[42] = state
+	gw.sessionsByAcpID["session-42"] = state
+
+	params, err := json.Marshal(acp.SessionUpdateParams{
+		SessionID: "session-42",
+		Update: acp.Update{
+			Type:   "run_error",
+			Status: "failed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal session update: %v", err)
+	}
+	note := acp.Notification{
+		JSONRPC: "2.0",
+		Method:  acp.MethodSessionUpdate,
+		Params:  params,
+	}
+	if err := gw.handleACPNotification(note); err != nil {
+		t.Fatalf("handleACPNotification returned error: %v", err)
+	}
+
+	msgs := callCapture.sentTexts()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 sent message, got %d", len(msgs))
+	}
+	if msgs[0] != "Run failed. Check the run log for details." {
+		t.Fatalf("unexpected message: %q", msgs[0])
+	}
+}
+
+func TestHandleACPNotificationConnectionClosedSignals(t *testing.T) {
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		acpClosed:       make(chan struct{}),
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+
+	note := acp.Notification{JSONRPC: "2.0", Method: acp.MethodConnectionClosed}
+	if err := gw.handleACPNotification(note); err != nil {
+		t.Fatalf("handleACPNotification returned error: %v", err)
+	}
+
+	select {
+	case <-gw.acpClosed:
+	default:
+		t.Fatal("expected acpClosed channel to be closed after connection/closed notification")
+	}
+
+	// Idempotent: a second notification must not panic on a re-close.
+	if err := gw.handleACPNotification(note); err != nil {
+		t.Fatalf("second handleACPNotification returned error: %v", err)
+	}
+}
+
+func TestHandleACPNotificationDropsMalformedPayload(t *testing.T) {
+	gw := &telegramGateway{
+		ctx:             context.Background(),
+		sessionsByChat:  make(map[int64]*telegramGatewaySession),
+		sessionsByAcpID: make(map[string]*telegramGatewaySession),
+	}
+	note := acp.Notification{
+		JSONRPC: "2.0",
+		Method:  acp.MethodSessionUpdate,
+		Params:  json.RawMessage(`{"sessionId": 12345}`), // wrong type, fails to unmarshal
+	}
+	if err := gw.handleACPNotification(note); err != nil {
+		t.Fatalf("expected malformed payload to be dropped without error, got %v", err)
+	}
+}
+
+func TestNormalizeTelegramConfigClampsTimingUpperBounds(t *testing.T) {
+	got := normalizeTelegramConfig(config.TelegramConfig{
+		PollTimeoutSec:    9000,
+		StatusIntervalSec: 9000,
+	})
+	if got.PollTimeout != telegramMaxPollTimeoutSec {
+		t.Fatalf("poll timeout = %d, want clamp to %d", got.PollTimeout, telegramMaxPollTimeoutSec)
+	}
+	want := time.Duration(telegramMaxStatusIntervalSec) * time.Second
+	if got.StatusInterval != want {
+		t.Fatalf("status interval = %s, want clamp to %s", got.StatusInterval, want)
+	}
+}
+
+func TestSetupTelegramGatewayRejectsMalformedToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	configFile := `[telegram]
+enabled = true
+bot_token = "not a valid token with spaces"
+`
+	if err := os.WriteFile(path, []byte(configFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err := setupTelegramGateway(ctx, &path)
+	if err == nil {
+		t.Fatal("expected gateway setup to reject a malformed bot token")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("expected malformed-token error, got %v", err)
+	}
+}
+
+func TestTelegramTokenPatternAcceptsRealisticToken(t *testing.T) {
+	valid := []string{
+		"123456789:AAFakeTokenValue_-09",
+		"1:A",
+	}
+	for _, tok := range valid {
+		if !telegramTokenPattern.MatchString(tok) {
+			t.Errorf("expected %q to be accepted", tok)
+		}
+	}
+	invalid := []string{
+		"",
+		"missingcolon",
+		"123:bad token",
+		"123:tok\nen",
+		"abc:123",
+	}
+	for _, tok := range invalid {
+		if telegramTokenPattern.MatchString(tok) {
+			t.Errorf("expected %q to be rejected", tok)
+		}
+	}
+}
+
+func TestTelegramHTTPClientTimeoutDerivesFromPollTimeout(t *testing.T) {
+	cfg := normalizeTelegramConfig(config.TelegramConfig{
+		PollTimeoutSec: 17,
+	})
+	got := telegramHTTPClientTimeout(cfg.PollTimeout)
+	want := 27 * time.Second
+	if got != want {
+		t.Fatalf("http timeout = %v, want %v", got, want)
+	}
+
+	cfgZero := normalizeTelegramConfig(config.TelegramConfig{})
+	got = telegramHTTPClientTimeout(cfgZero.PollTimeout)
+	want = (telegramDefaultPollTimeoutSec + 10) * time.Second
+	if got != want {
+		t.Fatalf("defaulted http timeout = %v, want %v", got, want)
+	}
+}
+
+func TestGatewayCmdHasTelegramSubcommand(t *testing.T) {
+	cfgPath := "config.toml"
+	cmd := gatewayCmd(&cfgPath)
+	children := cmd.Commands()
+	if len(children) != 1 || children[0].Name() != "telegram" {
+		t.Fatalf("gateway command children = %v", func() []string {
+			out := make([]string, 0, len(children))
+			for _, c := range children {
+				out = append(out, c.Name())
+			}
+			return out
+		}())
+	}
+
+	if children[0].Flags().Lookup("once") == nil {
+		t.Fatal("expected telegram command to expose --once flag")
+	}
+}
+
+func TestGatewayPollingRetryCaps(t *testing.T) {
+	if telegramPollRetryBase > telegramPollRetryMax {
+		t.Fatalf("poll retry base (%s) must be <= max (%s)", telegramPollRetryBase, telegramPollRetryMax)
+	}
+	if telegramPollRetryBase <= 0 || telegramPollRetryMax <= 0 {
+		t.Fatalf("poll retry durations must be positive: base=%s max=%s", telegramPollRetryBase, telegramPollRetryMax)
+	}
+}
+
+func TestSplitTextNil(t *testing.T) {
+	if chunks := splitText(""); len(chunks) != 0 {
+		t.Fatalf("splitText(\"\") = %#v", chunks)
+	}
+}
+
+func TestSetupTelegramGatewayReturnsDisabledWithoutToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	configFile := `[telegram]
+enabled = true
+bot_token = ""
+bot_token_env = "V100_TELEGRAM_TOKEN_GW_TEST"
+`
+	if err := os.WriteFile(path, []byte(configFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure this env var is unset for the test process to avoid accidental success.
+	t.Setenv("V100_TELEGRAM_TOKEN_GW_TEST", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if _, _, err := setupTelegramGateway(ctx, &path); err == nil {
+		t.Fatal("expected gateway setup to fail when token is missing")
+	}
+}

--- a/cmd/v100/main.go
+++ b/cmd/v100/main.go
@@ -76,6 +76,7 @@ func rootCmd() *cobra.Command {
 		compressCmd(&cfgPath),
 		dogfoodCmd(&cfgPath),
 		acpCmd(&cfgPath),
+		gatewayCmd(&cfgPath),
 	)
 	return root
 }

--- a/internal/acp/client.go
+++ b/internal/acp/client.go
@@ -1,0 +1,219 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Client is a small ACP client that speaks newline-delimited JSON-RPC over
+// a stream pair and exposes typed request/response methods.
+type Client struct {
+	conn          *Conn
+	notifications func(Notification)
+	nextID        int
+
+	pendingMu sync.Mutex
+	pending   map[string]chan responseMessage
+}
+
+type responseMessage struct {
+	Result json.RawMessage
+	Error  *Error
+	reqErr error
+}
+
+type rawResponse struct {
+	ID     json.RawMessage `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *Error          `json:"error"`
+}
+
+type rpcNotify struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// NewClient creates an ACP client bound to the provided transport.
+func NewClient(r io.Reader, w io.Writer, onNotification func(Notification)) *Client {
+	c := &Client{
+		conn:          NewConn(r, w),
+		notifications: onNotification,
+		pending:       make(map[string]chan responseMessage),
+	}
+	return c
+}
+
+// StartLaunch starts the background reader loop.
+func (c *Client) StartLaunch() {
+	go c.readLoop()
+}
+
+// Call invokes an ACP method and decodes the result into out when provided.
+func (c *Client) Call(ctx context.Context, method string, params any, out any) error {
+	if c == nil {
+		return errors.New("nil acp client")
+	}
+
+	c.pendingMu.Lock()
+	id := c.nextCallID()
+	idBuf := make(chan responseMessage, 1)
+	c.pending[id] = idBuf
+	c.pendingMu.Unlock()
+
+	req := Request{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Method:  method,
+	}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			c.clearPending(id)
+			return err
+		}
+		req.Params = raw
+	}
+
+	if err := c.conn.Send(req); err != nil {
+		c.clearPending(id)
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		c.clearPending(id)
+		return ctx.Err()
+	case res := <-idBuf:
+		if res.reqErr != nil {
+			return res.reqErr
+		}
+		if res.Error != nil {
+			msg := strings.TrimSpace(res.Error.Message)
+			if msg == "" {
+				msg = "ACP request failed"
+			}
+			return fmt.Errorf("%d: %s", res.Error.Code, msg)
+		}
+		if out == nil {
+			return nil
+		}
+		if len(res.Result) == 0 {
+			return nil
+		}
+		return json.Unmarshal(res.Result, out)
+	}
+}
+
+func (c *Client) clearPending(id string) {
+	c.pendingMu.Lock()
+	ch, ok := c.pending[id]
+	delete(c.pending, id)
+	c.pendingMu.Unlock()
+	if ok {
+		select {
+		case <-ch:
+		default:
+		}
+	}
+}
+
+func (c *Client) nextCallID() string {
+	c.nextID++
+	return strconv.FormatInt(int64(c.nextID), 10)
+}
+
+func (c *Client) readLoop() {
+	for {
+		raw, err := c.conn.ReadMessage()
+		if err != nil {
+			c.closePending(errors.New("acp connection closed"))
+			if c.notifications != nil {
+				c.notifications(Notification{
+					JSONRPC: JSONRPCVersion,
+					Method:  MethodConnectionClosed,
+					Params:  nil,
+				})
+			}
+			return
+		}
+		if len(raw) == 0 {
+			continue
+		}
+
+		var base rpcNotify
+		if err := json.Unmarshal(raw, &base); err != nil {
+			continue
+		}
+
+		if len(base.ID) > 0 {
+			var res rawResponse
+			if err := json.Unmarshal(raw, &res); err != nil {
+				continue
+			}
+			id := decodeRPCID(res.ID)
+			if id == "" {
+				continue
+			}
+			c.pendingMu.Lock()
+			ch, ok := c.pending[id]
+			delete(c.pending, id)
+			c.pendingMu.Unlock()
+			if ok {
+				select {
+				case ch <- responseMessage{Result: res.Result, Error: res.Error}:
+				default:
+				}
+			}
+			continue
+		}
+
+		if c.notifications == nil {
+			continue
+		}
+
+		c.notifications(Notification{
+			JSONRPC: base.JSONRPC,
+			Method:  base.Method,
+			Params:  base.Params,
+		})
+	}
+}
+
+func (c *Client) closePending(err error) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	for id, ch := range c.pending {
+		delete(c.pending, id)
+		select {
+		case ch <- responseMessage{reqErr: err}:
+		default:
+		}
+	}
+}
+
+func decodeRPCID(raw json.RawMessage) string {
+	var sid string
+	if raw == nil {
+		return ""
+	}
+	if err := json.Unmarshal(raw, &sid); err == nil {
+		return sid
+	}
+	var iid int64
+	if err := json.Unmarshal(raw, &iid); err == nil {
+		return strconv.FormatInt(iid, 10)
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return ""
+}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -49,6 +49,9 @@ const (
 	MethodSessionClose        = "session/close"
 	MethodSessionCancel       = "session/cancel"
 	MethodSessionUpdate       = "session/update"
+	// MethodConnectionClosed is a synthetic notification emitted by the client
+	// when the underlying transport reaches EOF or errors.
+	MethodConnectionClosed = "connection/closed"
 )
 
 const (
@@ -169,6 +172,7 @@ type SessionCapabilities struct {
 type SessionNewParams struct {
 	SessionID string `json:"sessionId,omitempty"`
 	CWD       string `json:"cwd,omitempty"`
+	RunDir    string `json:"runDir,omitempty"`
 }
 
 type SessionNewResult struct {

--- a/internal/acp/transport.go
+++ b/internal/acp/transport.go
@@ -84,6 +84,11 @@ func (c *Conn) SendNotification(method string, params any) error {
 	return c.write(notif)
 }
 
+// Send sends a JSON-RPC message (request, response, or notification).
+func (c *Conn) Send(v any) error {
+	return c.write(v)
+}
+
 func (c *Conn) write(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Update     UpdateConfig              `toml:"update"`
 	ATProto    ATProtoConfig             `toml:"atproto"`
 	ATProtoAlt ATProtoConfig             `toml:"alt-atproto"`
+	Telegram   TelegramConfig            `toml:"telegram"`
 	Embedding  EmbeddingConfig           `toml:"embedding"`
 }
 
@@ -42,6 +43,20 @@ type ATProtoConfig struct {
 	AppPassword    string `toml:"app_password"`     // direct value (fallback)
 	AppPasswordEnv string `toml:"app_password_env"` // env var name (preferred)
 	PDSURL         string `toml:"pds_url"`          // default "https://bsky.social"
+}
+
+// TelegramConfig holds credentials and run behavior for Telegram gateway.
+type TelegramConfig struct {
+	Enabled           bool    `toml:"enabled"`
+	BotToken          string  `toml:"bot_token"`               // direct bot token value
+	BotTokenEnv       string  `toml:"bot_token_env"`           // env var name (preferred)
+	PollTimeoutSec    int     `toml:"poll_timeout_seconds"`    // getUpdates timeout
+	RunDir            string  `toml:"run_dir"`                 // optional runs base directory
+	Workspace         string  `toml:"workspace"`               // optional working directory for tool execution
+	StreamResponses   bool    `toml:"stream_responses"`        // send chunk updates as they arrive
+	StatusIntervalSec int     `toml:"status_interval_seconds"` // status update throttle
+	AllowedChatIDs    []int64 `toml:"allowed_chat_ids"`        // whitelist of chat IDs
+	Provider          string  `toml:"provider"`                // override defaults.provider for the ACP child (empty = inherit)
 }
 
 // UpdateConfig defines auto-update behavior.
@@ -339,6 +354,15 @@ func DefaultConfig() *Config {
 			CompressProvider:      "glm",
 			StaleToolElideSteps:   20,
 		},
+		Telegram: TelegramConfig{
+			Enabled:           false,
+			BotTokenEnv:       "V100_TELEGRAM_BOT_TOKEN",
+			PollTimeoutSec:    30,
+			RunDir:            "",
+			Workspace:         "",
+			StreamResponses:   true,
+			StatusIntervalSec: 2,
+		},
 		UI: UIConfig{
 			Theme: "v100",
 		},
@@ -499,6 +523,17 @@ budget_cost_usd = 0.0
 
 [update]
 check_interval = "24h"
+
+[telegram]
+enabled = false
+bot_token = ""
+bot_token_env = "V100_TELEGRAM_BOT_TOKEN"
+poll_timeout_seconds = 30
+run_dir = ""                    # optional override of runs/ base directory
+workspace = ""                  # optional override of workspace used by sessions
+stream_responses = true         # stream agent responses via update notifications
+status_interval_seconds = 2
+allowed_chat_ids = []            # optional allowlist; empty means allow all chats
 `
 }
 
@@ -585,6 +620,7 @@ func loadConfigFile(path string) (*Config, error) {
 	applySandboxDefaults(&cfg.Sandbox, DefaultConfig().Sandbox)
 	applyWakeDefaults(&cfg.Wake, DefaultConfig().Wake)
 	applyUpdateDefaults(&cfg.Update, DefaultConfig().Update)
+	applyTelegramDefaults(&cfg.Telegram, DefaultConfig().Telegram)
 	if cfg.Embedding.Provider == "" {
 		cfg.Embedding.Provider = DefaultConfig().Embedding.Provider
 	}
@@ -769,6 +805,21 @@ func applyUpdateDefaults(dst *UpdateConfig, defaults UpdateConfig) {
 	}
 	if strings.TrimSpace(dst.CheckInterval) == "" {
 		dst.CheckInterval = defaults.CheckInterval
+	}
+}
+
+func applyTelegramDefaults(dst *TelegramConfig, defaults TelegramConfig) {
+	if dst == nil {
+		return
+	}
+	if strings.TrimSpace(dst.BotTokenEnv) == "" {
+		dst.BotTokenEnv = defaults.BotTokenEnv
+	}
+	if dst.PollTimeoutSec <= 0 {
+		dst.PollTimeoutSec = defaults.PollTimeoutSec
+	}
+	if dst.StatusIntervalSec <= 0 {
+		dst.StatusIntervalSec = defaults.StatusIntervalSec
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,6 +33,12 @@ func TestDefaultConfig(t *testing.T) {
 	if !containsString(cfg.Tools.Env.Redact, "*_TOKEN") {
 		t.Error("expected default tool env redaction patterns")
 	}
+	if cfg.Telegram.Enabled {
+		t.Error("expected telegram default to be disabled")
+	}
+	if cfg.Telegram.BotTokenEnv != "V100_TELEGRAM_BOT_TOKEN" {
+		t.Errorf("expected default telegram token env V100_TELEGRAM_BOT_TOKEN, got %q", cfg.Telegram.BotTokenEnv)
+	}
 	if cfg.Tools.Auth.GitHub.Mode != "disabled" {
 		t.Errorf("expected GitHub tool auth disabled by default, got %q", cfg.Tools.Auth.GitHub.Mode)
 	}
@@ -202,6 +208,24 @@ theme = "dracula"
 		t.Errorf("unexpected GitHub tool auth config: %+v", cfg.Tools.Auth.GitHub)
 	}
 
+	cfgEnvPath := filepath.Join(dir, "telegram_env.toml")
+	t.Setenv("V100_TELEGRAM_TOKEN_TEST", "env-token")
+	if err := os.WriteFile(cfgEnvPath, []byte(`
+[telegram]
+enabled = true
+bot_token = ""
+bot_token_env = "V100_TELEGRAM_TOKEN_TEST"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgFromEnv, err := Load(cfgEnvPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfgFromEnv.Telegram.Enabled {
+		t.Fatal("expected telegram enabled when explicitly configured, even without inline bot_token")
+	}
+
 	// Verify sh is migrated if missing
 	shEnabled := false
 	for _, tool := range cfg.Tools.Enabled {
@@ -342,6 +366,12 @@ func TestDefaultTOMLContainsAnthropic(t *testing.T) {
 	}
 	if !contains(toml, `memory_max_tokens = 256`) {
 		t.Error("default TOML should contain memory_max_tokens")
+	}
+	if !contains(toml, "[telegram]") {
+		t.Error("default TOML should contain telegram config section")
+	}
+	if !contains(toml, `bot_token_env = "V100_TELEGRAM_BOT_TOKEN"`) {
+		t.Error("default TOML should include telegram bot token env fallback")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `v100 gateway telegram` command backed by ACP sessions
- add Telegram config defaults, token env fallback, allowlist, provider override, voice transcription hook, and streaming/status behavior
- add an ACP client transport helper for gateway child-process communication

## Review note
I found and fixed one issue during review: `telegram.run_dir` was being used as ACP `cwd` when no workspace was configured. It now stays separate as `runDir`, while `workspace` controls `cwd`.

## Validation
- `make build`
- `make test`
- `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--provider` CLI flag to override the provider for ACP sessions.
  * Introduced gateway command with Telegram messaging support, featuring voice transcription, response streaming, and chat allowlisting controls.
  * Extended configuration system with Telegram settings including bot token management, polling intervals, and workspace options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->