### PR TITLE
fix: export workspace-safe go cache

### DIFF
--- a/docs/notes/CLAUDE.md
+++ b/docs/notes/CLAUDE.md
@@ -25,6 +25,8 @@ make build
 
 Avoid raw `go build ./...` or `go test ./...` from this checkout. The repo root can contain an ignored local `go/pkg/mod` tree, which makes those patterns walk cache files and fail with module-path errors.
 
+For a direct binary build, `./scripts/build.sh` now exports workspace-safe `GOCACHE` and `GOMODCACHE` before calling `go build`.
+
 ---
 
 ## Test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,10 @@ BINARY="${ROOT_DIR}/v100"
 
 cd "${ROOT_DIR}"
 
+export GOCACHE="${GOCACHE:-$ROOT_DIR/.gocache}"
+export GOMODCACHE="${GOMODCACHE:-$ROOT_DIR/.gomodcache}"
+export GOWORK=off
+
 echo "building ${BINARY}"
 go build -o "${BINARY}" ./cmd/v100
 


### PR DESCRIPTION
Export workspace-safe GOCACHE and GOMODCACHE in scripts/build.sh, and document the direct build wrapper in docs/notes/CLAUDE.md.

Validation: V100_SKIP_INSTALL=1 ./scripts/build.sh.